### PR TITLE
リスト登録関数をモバイル用UIと接続

### DIFF
--- a/app/actions/addMovie.test.ts
+++ b/app/actions/addMovie.test.ts
@@ -9,7 +9,9 @@ import {
 	listMoviesTable,
 	streamingServicesTable,
 } from "@/db/schema";
+import { SUPPORTED_SERVICES } from "@/app/consts";
 import { addMovie } from "./addMovie";
+import type { SupportedServiceSlug } from "@/app/consts";
 
 async function expectMovieRegistered({
 	title,
@@ -18,7 +20,7 @@ async function expectMovieRegistered({
 	listId,
 }: {
 	title: string;
-	slug: string;
+	slug: SupportedServiceSlug;
 	watchUrl: string;
 	listId: number;
 }) {
@@ -87,7 +89,7 @@ describe("addMovie", () => {
 
 		await expectMovieRegistered({
 			title: "ジュラシック・パーク",
-			slug: "netflix",
+			slug: SUPPORTED_SERVICES.NETFLIX.slug,
 			watchUrl:
 				"https://www.netflix.com/jp/title/60002360?s=i&trkid=258593161&vlang=ja&trg=more",
 			listId: testListId,
@@ -101,7 +103,7 @@ describe("addMovie", () => {
 
 		await expectMovieRegistered({
 			title: "ジュラシック・パーク",
-			slug: "unext",
+			slug: SUPPORTED_SERVICES.U_NEXT.slug,
 			watchUrl:
 				"https://video-share.unext.jp/video/title/SID0021132?utm_source=com.apple.UIKit.activity.CopyToPasteboard&utm_medium=social&utm_campaign=nonad-sns&rid=PM061312883",
 			listId: testListId,
@@ -115,7 +117,7 @@ describe("addMovie", () => {
 
 		await expectMovieRegistered({
 			title: "ジュラシック・パーク",
-			slug: "hulu",
+			slug: SUPPORTED_SERVICES.HULU.slug,
 			watchUrl: "https://www.hulu.jp/jurassic-park",
 			listId: testListId,
 		});
@@ -128,7 +130,7 @@ describe("addMovie", () => {
 
 		await expectMovieRegistered({
 			title: "ジュラシック・パーク",
-			slug: "prime-video",
+			slug: SUPPORTED_SERVICES.PRIME_VIDEO.slug,
 			watchUrl:
 				"https://watch.amazon.co.jp/detail?gti=amzn1.dv.gti.7ea9f6d9-bdc8-9b2e-97a9-c341306e36ef&territory=JP&ref_=share_ios_movie&r=web",
 			listId: testListId,
@@ -142,7 +144,7 @@ describe("addMovie", () => {
 
 		await expectMovieRegistered({
 			title: "ダイナソー",
-			slug: "disney-plus",
+			slug: SUPPORTED_SERVICES.DISNEY_PLUS.slug,
 			watchUrl:
 				"https://disneyplus.com/ja/browse/entity-fe34a97c-8f83-4c39-a08e-afc288e14d64?sharesource=iOS",
 			listId: testListId,

--- a/app/actions/addMovie.ts
+++ b/app/actions/addMovie.ts
@@ -9,68 +9,179 @@ import {
 	listMoviesTable,
 	streamingServicesTable,
 } from "@/db/schema";
+import type { Result } from "@/app/types/Result";
+import type { Tx } from "@/db/client";
+import { SUPPORTED_SERVICES } from "@/app/consts";
+import type { SupportedServiceSlug } from "@/app/consts";
+import { movieShareLinkSchema } from "../movieShareLinkSchema";
 
 type MovieInfo = {
 	title: string;
 	url: string;
-	serviceSlug: string;
+	serviceSlug: SupportedServiceSlug;
 };
 
-type TitleExtractor = (text: string) => string | null;
+export async function addMovie(
+	pastedText: string,
+	listId: number,
+): Promise<Result<MovieInfo>> {
+	const result = validateMovieShareLink(pastedText);
+
+	if (!result.success) {
+		return {
+			success: false,
+			error: { message: "もう一度やり直してください。" },
+		};
+	}
+
+	const url = extractUrl(pastedText);
+	if (!url) {
+		return {
+			success: false,
+			error: {
+				message: "URLを読み取れませんでした。もう一度やり直してください。",
+			},
+		};
+	}
+
+	const hostname = parseHostname(url);
+	if (!hostname) {
+		return {
+			success: false,
+			error: {
+				message: "URLを読み取れませんでした。もう一度やり直してください。",
+			},
+		};
+	}
+
+	const matcher = findMatcher(hostname);
+	if (!matcher) {
+		return {
+			success: false,
+			error: {
+				message: "URLを読み取れませんでした。もう一度やり直してください。",
+			},
+		};
+	}
+
+	const movieInfo = buildMovieInfo(url, matcher, pastedText);
+	if (!movieInfo) {
+		return {
+			success: false,
+			error: {
+				message: "映画を読み取れませんでした。もう一度やり直してください。",
+			},
+		};
+	}
+
+	const streamingServiceId = await findStreamingServiceId(
+		movieInfo.serviceSlug,
+	);
+	if (!streamingServiceId) {
+		return {
+			success: false,
+			error: {
+				message:
+					"ストリーミングサービスを読み取れませんでした。もう一度やり直してください。",
+			},
+		};
+	}
+
+	try {
+		await db.transaction(async (tx) => {
+			const movieId = await findOrCreateMovie(tx, movieInfo.title);
+
+			const movieServiceId = await createMovieService(
+				tx,
+				movieId,
+				streamingServiceId,
+				movieInfo.url,
+			);
+			await createListMovie(tx, listId, movieServiceId);
+		});
+	} catch (err) {
+		console.error(err);
+
+		return {
+			success: false,
+			error: { message: "すみませんが、もう一度やり直してください。" },
+		};
+	}
+
+	return {
+		success: true,
+		data: movieInfo,
+	};
+}
+
+function validateMovieShareLink(shareLink: string) {
+	return movieShareLinkSchema.safeParse({ value: shareLink });
+}
+
 type ServiceMatcher = {
-	slug: string;
-	matchUrl: (hostname: string) => boolean;
-	extractTitle: TitleExtractor;
+	slug: SupportedServiceSlug;
+	matchUrl(hostname: string): boolean;
+	extractTitle(text: string): string | null;
 };
+function serviceMatchers(): ServiceMatcher[] {
+	return [
+		{
+			slug: SUPPORTED_SERVICES.NETFLIX.slug,
+			matchUrl: (hostname) =>
+				hostname.includes(SUPPORTED_SERVICES.NETFLIX.hostname),
+			extractTitle: (text) => text.match(/「\s*(.+?)\s*」/)?.[1] ?? null,
+		},
+		{
+			slug: SUPPORTED_SERVICES.U_NEXT.slug,
+			matchUrl: (hostname) =>
+				hostname.includes(SUPPORTED_SERVICES.U_NEXT.hostname),
+			extractTitle: (text) => text.match(/「(.+?)」/)?.[1] ?? null,
+		},
+		{
+			slug: SUPPORTED_SERVICES.HULU.slug,
+			matchUrl: (hostname) =>
+				hostname.includes(SUPPORTED_SERVICES.HULU.hostname),
+			extractTitle: (text) => text.match(/「(.+?)」/)?.[1] ?? null,
+		},
+		{
+			slug: SUPPORTED_SERVICES.PRIME_VIDEO.slug,
+			matchUrl: (hostname) =>
+				hostname.includes(SUPPORTED_SERVICES.PRIME_VIDEO.hostname),
+			extractTitle: (text) =>
+				text.match(/、(.+?)を観ている/)?.[1] ??
+				text.match(/やあ、(.+?)を/)?.[1] ??
+				null,
+		},
+		{
+			slug: SUPPORTED_SERVICES.DISNEY_PLUS.slug,
+			matchUrl: (hostname) =>
+				hostname.includes(SUPPORTED_SERVICES.DISNEY_PLUS.hostname),
+			extractTitle: (text) => text.match(/「(.+?)」/)?.[1] ?? null,
+		},
+	];
+}
 
-const serviceMatchers: ServiceMatcher[] = [
-	{
-		slug: "netflix",
-		matchUrl: (hostname) => hostname.includes("netflix.com"),
-		extractTitle: (text) => text.match(/「\s*(.+?)\s*」/)?.[1] ?? null,
-	},
-	{
-		slug: "unext",
-		matchUrl: (hostname) => hostname.includes("unext.jp"),
-		extractTitle: (text) => text.match(/「(.+?)」/)?.[1] ?? null,
-	},
-	{
-		slug: "hulu",
-		matchUrl: (hostname) => hostname.includes("hulu.jp"),
-		extractTitle: (text) => text.match(/「(.+?)」/)?.[1] ?? null,
-	},
-	{
-		slug: "prime-video",
-		matchUrl: (hostname) => hostname.includes("amazon.co.jp"),
-		extractTitle: (text) =>
-			text.match(/、(.+?)を観ている/)?.[1] ??
-			text.match(/やあ、(.+?)を/)?.[1] ??
-			null,
-	},
-	{
-		slug: "disney-plus",
-		matchUrl: (hostname) => hostname.includes("disneyplus.com"),
-		extractTitle: (text) => text.match(/「(.+?)」/)?.[1] ?? null,
-	},
-];
-
-const extractUrl = (text: string): string | null => {
+function extractUrl(text: string): string | null {
 	return text.match(/https?:\/\/[^\s]+/)?.[0] ?? null;
-};
+}
 
-const parseHostname = (url: string): string | null => {
+function parseHostname(url: string): string | null {
 	try {
 		return new URL(url).hostname;
 	} catch {
 		return null;
 	}
-};
+}
 
-const findMatcher = (hostname: string): ServiceMatcher | null => {
-	return serviceMatchers.find((m) => m.matchUrl(hostname)) ?? null;
-};
+function findMatcher(hostname: string): ServiceMatcher | null {
+	return (
+		serviceMatchers().find((m) => {
+			return m.matchUrl(hostname);
+		}) ?? null
+	);
+}
 
-const normalizeTitle = (title: string): string => {
+function normalizeTitle(title: string): string {
 	return title
 		.replace(/･/g, "・")
 		.replace(/\(/g, "（")
@@ -79,86 +190,57 @@ const normalizeTitle = (title: string): string => {
 		.replace(/（吹替版）/g, "")
 		.replace(/（字幕版）/g, "")
 		.trim();
-};
+}
 
-const buildMovieInfo = (
+function buildMovieInfo(
 	url: string,
 	matcher: ServiceMatcher,
 	text: string,
-): MovieInfo | null => {
+): MovieInfo | null {
 	const rawTitle = matcher.extractTitle(text);
 	if (!rawTitle) return null;
 	const title = normalizeTitle(rawTitle);
 	return { title, url, serviceSlug: matcher.slug };
-};
+}
 
-const findStreamingServiceId = async (slug: string): Promise<number | null> => {
+async function findStreamingServiceId(
+	slug: SupportedServiceSlug,
+): Promise<number | null> {
 	const [service] = await db
 		.select()
 		.from(streamingServicesTable)
 		.where(eq(streamingServicesTable.slug, slug));
 	return service?.id ?? null;
-};
+}
 
-const findOrCreateMovie = async (title: string): Promise<number> => {
-	const [existing] = await db
+async function findOrCreateMovie(tx: Tx, title: string): Promise<number> {
+	const [existing] = await tx
 		.select()
 		.from(moviesTable)
 		.where(eq(moviesTable.title, title));
 	if (existing) return existing.id;
 
-	const [created] = await db.insert(moviesTable).values({ title }).returning();
+	const [created] = await tx.insert(moviesTable).values({ title }).returning();
 	return created.id;
-};
+}
 
-const createMovieService = async (
+async function createMovieService(
+	tx: Tx,
 	movieId: number,
 	streamingServiceId: number,
 	watchUrl: string,
-): Promise<number> => {
-	const [created] = await db
+): Promise<number> {
+	const [created] = await tx
 		.insert(movieServicesTable)
 		.values({ movieId, streamingServiceId, watchUrl })
 		.returning();
 	return created.id;
-};
+}
 
-const createListMovie = async (
+async function createListMovie(
+	tx: Tx,
 	listId: number,
 	movieServiceId: number,
-): Promise<void> => {
-	await db.insert(listMoviesTable).values({ listId, movieServiceId });
-};
-
-export async function addMovie(
-	pastedText: string,
-	listId: number,
-): Promise<MovieInfo | null> {
-	const url = extractUrl(pastedText);
-	if (!url) return null;
-
-	const hostname = parseHostname(url);
-	if (!hostname) return null;
-
-	const matcher = findMatcher(hostname);
-	if (!matcher) return null;
-
-	const movieInfo = buildMovieInfo(url, matcher, pastedText);
-	if (!movieInfo) return null;
-
-	const streamingServiceId = await findStreamingServiceId(
-		movieInfo.serviceSlug,
-	);
-	if (!streamingServiceId) return null;
-
-	const movieId = await findOrCreateMovie(movieInfo.title);
-
-	const movieServiceId = await createMovieService(
-		movieId,
-		streamingServiceId,
-		movieInfo.url,
-	);
-	await createListMovie(listId, movieServiceId);
-
-	return movieInfo;
+): Promise<void> {
+	await tx.insert(listMoviesTable).values({ listId, movieServiceId });
 }

--- a/app/actions/getUserListId.ts
+++ b/app/actions/getUserListId.ts
@@ -1,0 +1,14 @@
+"use server";
+
+import { eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { listsTable } from "@/db/schema";
+
+export async function getUserList(userId: number): Promise<number | null> {
+	const [list] = await db
+		.select({ id: listsTable.id })
+		.from(listsTable)
+		.where(eq(listsTable.userId, userId));
+
+	return list?.id ?? null;
+}

--- a/app/consts.ts
+++ b/app/consts.ts
@@ -1,0 +1,32 @@
+export const SUPPORTED_SERVICES = {
+	U_NEXT: {
+		name: "U-NEXT",
+		slug: "unext",
+		hostname: "unext.jp",
+	},
+	NETFLIX: {
+		name: "Netflix",
+		slug: "netflix",
+		hostname: "netflix.com",
+	},
+	HULU: {
+		name: "Hulu",
+		slug: "hulu",
+		hostname: "hulu.jp",
+	},
+	PRIME_VIDEO: {
+		name: "Prime Video",
+		slug: "prime-video",
+		hostname: "amazon.co.jp",
+	},
+	DISNEY_PLUS: {
+		name: "Disney+",
+		slug: "disney-plus",
+		hostname: "disneyplus.com",
+	},
+} as const;
+
+export type SupportedServiceName =
+	(typeof SUPPORTED_SERVICES)[keyof typeof SUPPORTED_SERVICES]["name"];
+export type SupportedServiceSlug =
+	(typeof SUPPORTED_SERVICES)[keyof typeof SUPPORTED_SERVICES]["slug"];

--- a/app/login/actions/sendLoginCode.ts
+++ b/app/login/actions/sendLoginCode.ts
@@ -7,22 +7,25 @@ import { Resend } from "resend";
 import { checkRateLimit, recordAttempt } from "@/lib/rateLimit";
 import type { Result } from "@/app/types/Result";
 import { db } from "@/db/client";
+import type { Tx } from "@/db/client";
 import { authTokensTable, usersTable } from "@/db/schema";
 import { emailSchema } from "../loginSchemas";
 import LoginMailTemplate from "../components/LoginMailTemplate";
 
-export async function sendLoginCode(email: string): Promise<Result> {
+export async function sendLoginCode(email: string, now: Date): Promise<Result> {
 	const headersList = await headers();
-	const ipAddress =
-		headersList.get("x-forwarded-for")?.split(",")[0] ||
-		headersList.get("x-real-ip") ||
-		"unknown";
 
-	const rateLimit = await checkRateLimit(ipAddress, "code_send");
+	const { limit, ipAddress } = await checkRateLimit({
+		ipAddress:
+			headersList.get("x-forwarded-for")?.split(",")[0] ||
+			headersList.get("x-real-ip") ||
+			"unknown",
+		attemptType: "code_send",
+	});
 
-	if (!rateLimit.allowed && rateLimit.retryAfter) {
+	if (!limit.allowed && limit.retryAfter) {
 		const minutesUntilRetry = Math.ceil(
-			(rateLimit.retryAfter.getTime() - Date.now()) / 60000,
+			(limit.retryAfter.getTime() - now.getTime()) / 60000,
 		);
 
 		return {
@@ -50,49 +53,29 @@ export async function sendLoginCode(email: string): Promise<Result> {
 		};
 	}
 
-	const time = createTimeContext();
 	const loginCode = generateLoginCode();
-	const hashedCode = hashLoginCode(loginCode);
-	const url = resolveBaseUrl();
 
 	try {
 		await db.transaction(async (tx) => {
-			await tx
-				.delete(authTokensTable)
-				.where(
-					and(
-						eq(authTokensTable.email, email),
-						eq(authTokensTable.tokenType, "login_code"),
-					),
-				);
-
-			const [user] = await tx
-				.select()
-				.from(usersTable)
-				.where(eq(usersTable.email, email));
-
-			await tx.insert(authTokensTable).values({
-				token: hashedCode,
-				tokenType: "login_code",
+			await deleteLoginCode({ tx, email });
+			await insertLoginCode({
+				tx,
 				email,
-				userId: user?.id ?? null,
-				expiresAt: time.expiresAt,
-				createdAt: time.now,
+				token: hashLoginCode(loginCode),
+				expiresAt: createExpiresAt(now),
+				createdAt: now,
 			});
 		});
 
-		try {
-			await sendLoginMail(email, loginCode, url);
-		} catch (err) {
-			console.error(err);
-			await db
-				.delete(authTokensTable)
-				.where(
-					and(
-						eq(authTokensTable.email, email),
-						eq(authTokensTable.tokenType, "login_code"),
-					),
-				);
+		const response = await sendLoginMail({
+			email,
+			loginCode,
+			url: resolveBaseUrl(),
+		});
+
+		if (response.error) {
+			await deleteLoginCode({ email });
+
 			await recordAttempt({
 				executor: db,
 				ipAddress,
@@ -100,6 +83,8 @@ export async function sendLoginCode(email: string): Promise<Result> {
 				attemptType: "code_send",
 				success: false,
 			});
+
+			console.error(response.error);
 
 			return {
 				success: false,
@@ -139,16 +124,8 @@ function hashLoginCode(code: string) {
 	return crypto.createHash("sha256").update(code).digest("hex");
 }
 
-type TimeContext = {
-	now: Date;
-	expiresAt: Date;
-};
-function createTimeContext(): TimeContext {
-	const now = new Date();
-	return {
-		now,
-		expiresAt: new Date(now.getTime() + 10 * 60 * 1000),
-	};
+function createExpiresAt(now: Date) {
+	return new Date(now.getTime() + 10 * 60 * 1000);
 }
 
 function resolveBaseUrl() {
@@ -157,10 +134,58 @@ function resolveBaseUrl() {
 		: "http://localhost:4321";
 }
 
-async function sendLoginMail(email: string, loginCode: string, url: string) {
+async function deleteLoginCode({ tx, email }: { tx?: Tx; email: string }) {
+	const executor = tx || db;
+	await executor
+		.delete(authTokensTable)
+		.where(
+			and(
+				eq(authTokensTable.email, email),
+				eq(authTokensTable.tokenType, "login_code"),
+			),
+		);
+}
+
+async function insertLoginCode({
+	tx,
+	email,
+	token,
+	expiresAt,
+	createdAt,
+}: {
+	tx: Tx;
+	email: string;
+	token: string;
+	expiresAt: Date;
+	createdAt: Date;
+}) {
+	const [user] = await tx
+		.select()
+		.from(usersTable)
+		.where(eq(usersTable.email, email));
+
+	await tx.insert(authTokensTable).values({
+		token,
+		tokenType: "login_code",
+		email,
+		userId: user?.id ?? null,
+		expiresAt,
+		createdAt,
+	});
+}
+
+async function sendLoginMail({
+	email,
+	loginCode,
+	url,
+}: {
+	email: string;
+	loginCode: string;
+	url: string;
+}) {
 	const resend = new Resend(process.env.RESEND_API_KEY);
 
-	await resend.emails.send({
+	return await resend.emails.send({
 		from:
 			process.env.NODE_ENV === "development"
 				? "onboarding@resend.dev"

--- a/app/login/actions/verifyLoginCode.ts
+++ b/app/login/actions/verifyLoginCode.ts
@@ -5,6 +5,7 @@ import { cookies, headers } from "next/headers";
 import crypto from "crypto";
 import { eq, and, gt } from "drizzle-orm";
 import { db } from "@/db/client";
+import type { Tx } from "@/db/client";
 import { authTokensTable, usersTable } from "@/db/schema";
 import { loginCodeSchema } from "../loginSchemas";
 import { generateSessionToken, generateTempSessionToken } from "@/lib/auth";
@@ -12,10 +13,13 @@ import { addDays } from "@/lib/auth";
 import { checkRateLimit, recordAttempt } from "@/lib/rateLimit";
 import { generateDeviceId } from "@/lib/devices";
 
-export async function verifyLoginCode(loginCode: string): Promise<
+export async function verifyLoginCode(
+	loginCode: string,
+	now: Date,
+): Promise<
 	Result<{
 		email: string;
-		needsRegistration: boolean;
+		isNewUser: boolean;
 	}>
 > {
 	const result = validateLoginCode(loginCode);
@@ -28,18 +32,19 @@ export async function verifyLoginCode(loginCode: string): Promise<
 	}
 
 	const headersList = await headers();
-	const ipAddress =
-		headersList.get("x-forwarded-for")?.split(",")[0] ||
-		headersList.get("x-real-ip") ||
-		"unknown";
-	const userAgent = headersList.get("user-agent") || "Unknown";
-	const deviceId = generateDeviceId(userAgent);
 
-	const rateLimit = await checkRateLimit(ipAddress, "code_verify");
+	const { limit, ipAddress } = await checkRateLimit({
+		ipAddress:
+			headersList.get("x-forwarded-for")?.split(",")[0] ||
+			headersList.get("x-real-ip") ||
+			"unknown",
+		attemptType: "code_verify",
+	});
 
-	if (!rateLimit.allowed && rateLimit.retryAfter) {
-		const minutesUntilRetry = Math.ceil(
-			(rateLimit.retryAfter.getTime() - Date.now()) / 60000,
+	if (!limit.allowed && limit.retryAfter) {
+		const minutesUntilRetry = calcurateMinutesUntilRetry(
+			limit.retryAfter.getTime(),
+			now.getTime(),
 		);
 
 		return {
@@ -50,20 +55,11 @@ export async function verifyLoginCode(loginCode: string): Promise<
 		};
 	}
 
-	const now = new Date();
+	const deviceId = generateDeviceId(headersList.get("user-agent") || "Unknown");
 
 	try {
-		const result = await db.transaction(async (tx) => {
-			const [token] = await tx
-				.select()
-				.from(authTokensTable)
-				.where(
-					and(
-						eq(authTokensTable.token, hashLoginCode(loginCode)),
-						eq(authTokensTable.tokenType, "login_code"),
-						gt(authTokensTable.expiresAt, now),
-					),
-				);
+		const txResult = await db.transaction(async (tx) => {
+			const token = await searchLoginCode({ tx, inputtedCode: loginCode, now });
 
 			if (!token) {
 				await recordAttempt({
@@ -98,42 +94,28 @@ export async function verifyLoginCode(loginCode: string): Promise<
 				.where(eq(usersTable.email, token.email));
 
 			if (user) {
-				await tx
-					.delete(authTokensTable)
-					.where(
-						and(
-							eq(authTokensTable.tokenType, "session_token"),
-							eq(authTokensTable.userId, user.id),
-							eq(authTokensTable.deviceId, deviceId),
-						),
-					);
-
-				const sessionToken = await generateSessionToken({
-					userId: user.id,
-					email: user.email,
+				const { sessionToken: newToken, expiresAt } = await updateSessionToken({
+					tx,
+					user,
 					deviceId,
-				});
-
-				const expiresAt = addDays(now, 30);
-
-				await tx.insert(authTokensTable).values({
-					token: sessionToken,
-					tokenType: "session_token",
-					deviceId,
-					email: user.email,
-					userId: user.id,
-					createdAt: now,
-					expiresAt: expiresAt,
+					now,
 				});
 
 				return {
 					success: true,
-					token: sessionToken,
-					user,
-					needsRegistration: false,
-					expiresAt,
+					data: {
+						token: newToken,
+						email: user.email,
+						isNewUser: false,
+						expiresAt,
+					},
 				};
 			}
+
+			await insertTempToken({
+                tempToken: generateTempSessionToken(),
+                expiresAt: addMinutes(now, 15)
+            });
 
 			const tempToken = generateTempSessionToken();
 			const expiresAt = addMinutes(now, 15);
@@ -150,44 +132,35 @@ export async function verifyLoginCode(loginCode: string): Promise<
 
 			return {
 				success: true,
-				token: tempToken,
-				user: { id: null, email: token.email },
-				needsRegistration: true,
-				expiresAt,
+				data: {
+					token: tempToken,
+					email: token.email,
+					isNewUser: true,
+					expiresAt,
+				},
 			};
 		});
 
-		const cookieStore = await cookies();
-
-		if (result.token && result.success) {
-			if (result.needsRegistration) {
-				cookieStore.set("temp_session_token", result.token, {
-					httpOnly: true,
-					secure: true,
-					sameSite: "lax",
-					expires: result.expiresAt,
-				});
-			} else {
-				cookieStore.set("session_token", result.token, {
-					httpOnly: true,
-					secure: true,
-					sameSite: "lax",
-					expires: result.expiresAt,
-				});
-			}
-
+		if (txResult.error) {
 			return {
-				data: {
-					email: result.user.email,
-					needsRegistration: result.needsRegistration,
-				},
-				success: true,
+				success: false,
+				error: txResult.error,
 			};
 		}
 
+		const { email, isNewUser, token, expiresAt } = txResult.data;
+		await setCookie({
+			isNewUser: isNewUser,
+			token,
+			expiresAt,
+		});
+
 		return {
-			success: false,
-			error: { message: "ログインに失敗しました。もう一度お試しください。" },
+			data: {
+				email,
+				isNewUser: isNewUser,
+			},
+			success: true,
 		};
 	} catch (err) {
 		console.error(err);
@@ -202,10 +175,113 @@ function validateLoginCode(loginCode: string) {
 	return loginCodeSchema.safeParse({ value: loginCode });
 }
 
+async function searchLoginCode({
+	tx,
+	inputtedCode,
+	now,
+}: {
+	tx: Tx;
+	inputtedCode: string;
+	now: Date;
+}) {
+	const [token] = await tx
+		.select()
+		.from(authTokensTable)
+		.where(
+			and(
+				eq(authTokensTable.token, hashLoginCode(inputtedCode)),
+				eq(authTokensTable.tokenType, "login_code"),
+				gt(authTokensTable.expiresAt, now),
+			),
+		);
+	return token;
+}
+
+async function updateSessionToken({
+	tx,
+	user,
+	deviceId,
+	now,
+}: {
+	tx: Tx;
+	user: {
+		id: number;
+		publicId: string;
+		email: string;
+	};
+	deviceId: string;
+	now: Date;
+}) {
+	await tx
+		.delete(authTokensTable)
+		.where(
+			and(
+				eq(authTokensTable.tokenType, "session_token"),
+				eq(authTokensTable.userId, user.id),
+				eq(authTokensTable.deviceId, deviceId),
+			),
+		);
+
+	const sessionToken = await generateSessionToken({
+		userId: user.id,
+		email: user.email,
+		deviceId,
+	});
+
+	const expiresAt = addDays(now, 30);
+
+	await tx.insert(authTokensTable).values({
+		token: sessionToken,
+		tokenType: "session_token",
+		deviceId,
+		email: user.email,
+		userId: user.id,
+		createdAt: now,
+		expiresAt: expiresAt,
+	});
+
+	return { sessionToken, expiresAt };
+}
+
+async function insertTempToken({
+	tempToken,
+	expiresAt,
+}: {
+	tempToken: string;
+	expiresAt: Date;
+}) {}
+
+function calcurateMinutesUntilRetry(
+	retryAfterTime: number,
+	currentTime: number,
+) {
+	return Math.ceil((retryAfterTime - currentTime) / 60000);
+}
+
 function hashLoginCode(code: string) {
 	return crypto.createHash("sha256").update(code).digest("hex");
 }
 
 function addMinutes(date: Date, minutes: number) {
 	return new Date(date.getTime() + minutes * 60 * 1000);
+}
+
+async function setCookie({
+	isNewUser,
+	token,
+	expiresAt,
+}: {
+	isNewUser: boolean;
+	token: string;
+	expiresAt: Date;
+}) {
+	const cookieStore = await cookies();
+	const key = isNewUser ? "temp_session_token" : "session_token";
+
+	cookieStore.set(key, token, {
+		httpOnly: true,
+		secure: true,
+		sameSite: "lax",
+		expires: expiresAt,
+	});
 }

--- a/app/login/components/LoginForm/LoginFormContent/index.tsx
+++ b/app/login/components/LoginForm/LoginFormContent/index.tsx
@@ -14,9 +14,13 @@ export default function LoginFormContent() {
 	const [status, setStatus] = useState<Status>("idle");
 	const [errorMessage, setErrorMessage] = useState<string>("");
 
+	const now = new Date();
+
 	const handleEmailSubmit = async (data: { value: string }) => {
 		setStatus("loading");
-		const result = await sendLoginCode(data.value);
+    
+		const result = await sendLoginCode(data.value, now);
+    
 		setTimeout(() => {
 			if (result.success) {
 				return setStatus("sent");
@@ -29,12 +33,12 @@ export default function LoginFormContent() {
 
 	const handleLoginCodeSubmit = async (data: { value: string }) => {
 		setStatus("loading");
-		const result = await verifyLoginCode(data.value);
+		const result = await verifyLoginCode(data.value, now);
 
 		if (result.success) {
-			const { email, needsRegistration } = result.data;
+			const { email, isNewUser } = result.data;
 			sessionStorage.setItem("registrationEmail", email);
-			return needsRegistration ? redirect("/register") : redirect("/");
+			return isNewUser ? redirect("/register") : redirect("/");
 		}
 
 		setStatus("error");

--- a/app/movieShareLinkSchema.ts
+++ b/app/movieShareLinkSchema.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import { SUPPORTED_SERVICES } from "@/app/consts";
+
+const extractUrl = (text: string): string | null => {
+	return text.match(/https?:\/\/[^\s]+/)?.[0] ?? null;
+};
+
+const parseHostname = (url: string): string | null => {
+	try {
+		return new URL(url).hostname;
+	} catch {
+		return null;
+	}
+};
+
+const isSupportedHost = (hostname: string): boolean => {
+	return Object.values(SUPPORTED_SERVICES).some((service) => {
+		return (
+			hostname === service.hostname ||
+			hostname.endsWith(`.${service.hostname}`)
+		);
+	});
+};
+
+export const movieShareLinkSchema = z.object({
+	value: z
+		.string()
+		.min(1, "共有リンクを貼り付けてください。")
+		.refine((val) => extractUrl(val) !== null, "URLが含まれていません。")
+		.refine((val) => {
+			const url = extractUrl(val);
+			if (!url) return false;
+			const hostname = parseHostname(url);
+			if (!hostname) return false;
+			return isSupportedHost(hostname);
+		}, "対応していないサービスのリンクです。"),
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,14 @@
 import { headers } from "next/headers";
+import { verifySessionToken } from "@/lib/auth";
+import { getUserList } from "@/app/actions/getUserListId";
 import MovieTitleForm from "@/components/MovieInputForm";
 import PcForm from "@/components/MovieInputForm/PcForm";
 import MobileForm from "@/components/MovieInputForm/MobileForm";
 
 export default async function Home() {
+	const isVerified = await verifySessionToken();
+	const listId = isVerified ? await getUserList(isVerified.userId) : null;
+
 	const headersList = await headers();
 	const userAgent = headersList.get("user-agent") || "";
 
@@ -16,8 +21,8 @@ export default async function Home() {
 			<MovieTitleForm
 				initialIsMobile={isMobileUA}
 				userAgent={userAgent}
-				PcForm={<PcForm />}
-				MobileForm={<MobileForm />}
+				PcForm={<PcForm listId={listId} />}
+				MobileForm={<MobileForm listId={listId} />}
 			/>
 		</div>
 	);

--- a/components/MovieInputForm/Form/index.tsx
+++ b/components/MovieInputForm/Form/index.tsx
@@ -4,18 +4,15 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { Textarea } from "../../ui/textarea";
 
-type Props = ComponentProps<"textarea"> & {
-	onPaste?: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void;
-};
+type Props = ComponentProps<"textarea">;
 
-export default function Form({ className, onPaste, ...props }: Props) {
+export default function Form({ className, ...props }: Props) {
 	return (
 		<Textarea
 			className={cn(
 				"border-background-light-2 focus-visible:ring-2 focus-visible:ring-background-light-2 px-2 transition-shadow duration-300",
 				className,
 			)}
-			onPaste={onPaste}
 			{...props}
 		/>
 	);

--- a/components/MovieInputForm/MobileForm/MobileFormTextarea/index.tsx
+++ b/components/MovieInputForm/MobileForm/MobileFormTextarea/index.tsx
@@ -1,13 +1,78 @@
 "use client";
 
+import type z from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useCallback, useEffect, useRef } from "react";
+import { useForm, useWatch } from "react-hook-form";
 import Form from "@/components/MovieInputForm/Form";
+import { addMovie } from "@/app/actions/addMovie";
+import { movieShareLinkSchema } from "@/app/movieShareLinkSchema";
 
-export default function MobileFormTextarea() {
+type MovieShareLinkData = z.infer<typeof movieShareLinkSchema>;
+
+type Props = {
+	listId: number | null;
+};
+
+export default function MobileFormTextarea({ listId }: Props) {
+	const {
+		register,
+		formState: { errors },
+		control,
+		trigger,
+	} = useForm<MovieShareLinkData>({
+		resolver: zodResolver(movieShareLinkSchema),
+		mode: "onChange",
+	});
+
+	const handleListRegistration = useCallback(
+		async (shareLink: string) => {
+			if (listId === null) return;
+			const data = await addMovie(shareLink, listId);
+		},
+		[listId],
+	);
+
+	const shareLink = useWatch({ control, name: "value" });
+	const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		if (shareLink === undefined) return;
+		let canceled = false;
+
+		const run = async () => {
+			const isValid = await trigger("value");
+			if (!isValid || canceled) return;
+
+			if (debounceRef.current) {
+				clearTimeout(debounceRef.current);
+			}
+
+			debounceRef.current = setTimeout(() => {
+				void handleListRegistration(shareLink);
+			}, 400);
+		};
+
+		void run();
+
+		return () => {
+			canceled = true;
+			if (debounceRef.current) {
+				clearTimeout(debounceRef.current);
+			}
+		};
+	}, [shareLink, trigger, handleListRegistration]);
+
 	return (
-		<Form
-			className="min-h-[calc(4lh+(calc(var(--spacing)*4)))] placeholder-shown:text-ellipsis placeholder-shown:overflow-hidden wrap-break-word"
-			name="movie-share-link"
-			placeholder="「 ジュラシック・パーク 」 をNetflix で今 す ぐチ ェ ッ クhttps://www.netflix.com/jp/title/60002360?s=i&trkid=258593161&vlang=ja&trg=more"
-		/>
+		<>
+			<Form
+				className="min-h-[calc(4lh+(calc(var(--spacing)*4)))] placeholder-shown:text-ellipsis placeholder-shown:overflow-hidden wrap-break-word"
+				placeholder="「 ジュラシック・パーク 」 をNetflix で今 す ぐチ ェ ッ クhttps://www.netflix.com/jp/title/60002360?s=i&trkid=258593161&vlang=ja&trg=more"
+				{...register("value")}
+			/>
+			{errors.value && (
+				<p className="text-sm text-red-500">{errors.value.message}</p>
+			)}
+		</>
 	);
 }

--- a/components/MovieInputForm/MobileForm/index.tsx
+++ b/components/MovieInputForm/MobileForm/index.tsx
@@ -2,14 +2,18 @@ import Tutorial from "../Tutorial";
 import TutorialContent from "../Tutorial/Content";
 import MobileFormTextarea from "./MobileFormTextarea";
 
-export default function MobileForm() {
+type Props = {
+	listId: number | null;
+};
+
+export default function MobileForm({ listId }: Props) {
 	return (
 		<div className="w-full md:px-10 flex flex-col justify-center items-center">
 			<div className="w-full flex flex-col gap-4">
 				<div className="text-foreground-dark-2 flex justify-center py-2 font-medium">
 					作品の共有リンクをペースト
 				</div>
-				<MobileFormTextarea />
+				<MobileFormTextarea listId={listId} />
 			</div>
 
 			<Tutorial title="共有リンクの取得方法">

--- a/components/MovieInputForm/PcForm/index.tsx
+++ b/components/MovieInputForm/PcForm/index.tsx
@@ -1,6 +1,11 @@
 import Form from "@/components/MovieInputForm/Form";
 
-export default function PcForm() {
+type Props = {
+	listId: number | null;
+};
+
+export default function PcForm({ listId }: Props) {
+	void listId;
 	return (
 		<div className="w-full md:px-10 flex flex-col justify-center items-center">
 			<div className="w-full flex flex-col gap-4">

--- a/components/MovieInputForm/Tutorial/Content/LinkShareSteps/ShareMark/index.tsx
+++ b/components/MovieInputForm/Tutorial/Content/LinkShareSteps/ShareMark/index.tsx
@@ -2,6 +2,7 @@ import ShareArrowIcon from "@/components/ui/Icons/ShareArrowIcon";
 import ShareAndroidIcon from "@/components/ui/Icons/ShareAndroidIcon";
 import ShareSendIcon from "@/components/ui/Icons/ShareSendIcon";
 import ShareIosIcon from "@/components/ui/Icons/ShareIosIcon";
+import { SUPPORTED_SERVICES } from "@/app/consts";
 
 import type { ServiceName } from "../..";
 
@@ -11,7 +12,7 @@ type Props = {
 
 function Content({ serviceName }: Props) {
 	switch (serviceName) {
-		case "Netflix":
+		case SUPPORTED_SERVICES.NETFLIX.name:
 			return (
 				<div className="w-12">
 					<div className="aspect-square flex flex-col justify-center">
@@ -23,7 +24,7 @@ function Content({ serviceName }: Props) {
 				</div>
 			);
 
-		case "Hulu":
+		case SUPPORTED_SERVICES.HULU.name:
 			return (
 				<div className="text-background-light-3 bg-background-light-2 rounded-full">
 					<div className="flex items-center px-2 py-1">
@@ -35,7 +36,7 @@ function Content({ serviceName }: Props) {
 				</div>
 			);
 
-		case "U-NEXT":
+		case SUPPORTED_SERVICES.U_NEXT.name:
 			return (
 				<div className="w-12">
 					<div className="aspect-square flex flex-col justify-center">
@@ -47,7 +48,7 @@ function Content({ serviceName }: Props) {
 				</div>
 			);
 
-		case "Prime Video":
+		case SUPPORTED_SERVICES.PRIME_VIDEO.name:
 			return (
 				<div className="w-12">
 					<div className="aspect-square flex flex-col justify-center">
@@ -59,7 +60,7 @@ function Content({ serviceName }: Props) {
 				</div>
 			);
 
-		case "Disney+":
+		case SUPPORTED_SERVICES.DISNEY_PLUS.name:
 			return (
 				<div className="flex items-center px-2 py-1">
 					<div className="flex justify-center items-center">

--- a/components/MovieInputForm/Tutorial/Content/index.tsx
+++ b/components/MovieInputForm/Tutorial/Content/index.tsx
@@ -6,14 +6,11 @@ import { Button } from "@/components/ui/button";
 import ShareMark from "./LinkShareSteps/ShareMark";
 import MenuMark from "./LinkShareSteps/MenuMark";
 import Description from "./LinkShareSteps/Description";
+import { SUPPORTED_SERVICES } from "@/app/consts";
 import "./animation.css";
 
 export type ServiceName =
-	| "U-NEXT"
-	| "Hulu"
-	| "Prime Video"
-	| "Netflix"
-	| "Disney+";
+	(typeof SUPPORTED_SERVICES)[keyof typeof SUPPORTED_SERVICES]["name"];
 
 export type MenuType = "more" | "unext-copy" | "os-copy";
 
@@ -29,7 +26,7 @@ type ServiceDataItem = {
 
 const serviceData: ServiceDataItem[] = [
 	{
-		serviceName: "Netflix",
+		serviceName: SUPPORTED_SERVICES.NETFLIX.name,
 		shareLinkExample:
 			"「 ジュラシック・パーク 」 をNetflix で今 す ぐチ ェ ッ ク \n\nhttps://www.netflix.com/jp/title/60002360?s=i&trkid=258593161&vlang=ja&trg=more",
 		steps: [
@@ -47,7 +44,7 @@ const serviceData: ServiceDataItem[] = [
 		],
 	},
 	{
-		serviceName: "U-NEXT",
+		serviceName: SUPPORTED_SERVICES.U_NEXT.name,
 		shareLinkExample:
 			"「ジュラシック・パーク」をU-NEXTで視聴 https://video-share.unext.jp/video/title/SID0021132?utm_source=com.apple.UIKit.activity.CopyToPasteboard&utm_medium=social&utm_campaign=nonad-sns&rid=PM061312883",
 		steps: [
@@ -65,7 +62,7 @@ const serviceData: ServiceDataItem[] = [
 		],
 	},
 	{
-		serviceName: "Prime Video",
+		serviceName: SUPPORTED_SERVICES.PRIME_VIDEO.name,
 		shareLinkExample:
 			"やあ、ジュラシック・パーク (吹替版)を観ているよ。Prime Videoを今すぐチェックする https://watch.amazon.co.jp/detail?gti=amzn1.dv.gti.7ea9f6d9-bdc8-9b2e-97a9-c341306e36ef&territory=JP&ref_=share_ios_movie&r=web",
 		steps: [
@@ -78,7 +75,7 @@ const serviceData: ServiceDataItem[] = [
 		],
 	},
 	{
-		serviceName: "Hulu",
+		serviceName: SUPPORTED_SERVICES.HULU.name,
 		shareLinkExample:
 			"Huluで「ジュラシック･パーク」を視聴中! https://www.hulu.jp/jurassic-park",
 		steps: [
@@ -91,7 +88,7 @@ const serviceData: ServiceDataItem[] = [
 		],
 	},
 	{
-		serviceName: "Disney+",
+		serviceName: SUPPORTED_SERVICES.DISNEY_PLUS.name,
 		shareLinkExample:
 			"https://disneyplus.com/ja/browse/entity-fe34a97c-8f83-4c39-a08e-afc288e14d64?sharesource=iOS Disney+の「ダイナソー」がおすすめなので、チェックしてみてください。",
 		steps: [

--- a/db/client.ts
+++ b/db/client.ts
@@ -1,5 +1,8 @@
 import { createClient } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
+import dotenv from "dotenv";
+
+dotenv.config({ path: ".env" });
 
 const tursoDatabaseUrl = process.env.TURSO_DATABASE_URL;
 
@@ -24,4 +27,7 @@ const client =
 export const db = drizzle(client);
 
 export type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
-export type Executor = Pick<Tx, "select" | "insert" | "update" | "delete" | "query">;
+export type Executor = Pick<
+	Tx,
+	"select" | "insert" | "update" | "delete" | "query"
+>;

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,4 +1,5 @@
 import { int, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import type { SupportedServiceName, SupportedServiceSlug } from "@/app/consts";
 
 export const usersTable = sqliteTable("users_table", {
 	id: int().primaryKey({ autoIncrement: true }),
@@ -8,8 +9,8 @@ export const usersTable = sqliteTable("users_table", {
 
 export const streamingServicesTable = sqliteTable("streaming_services_table", {
 	id: int().primaryKey({ autoIncrement: true }),
-	name: text().notNull(),
-	slug: text().notNull().unique(),
+	name: text().$type<SupportedServiceName>().notNull(),
+	slug: text().$type<SupportedServiceSlug>().notNull().unique(),
 });
 
 export const moviesTable = sqliteTable("movies_table", {
@@ -48,7 +49,9 @@ export const listMoviesTable = sqliteTable("list_movies_table", {
 
 export const authTokensTable = sqliteTable("auth_tokens_table", {
 	token: text("token").notNull().unique(),
-	tokenType: text("token_type").notNull(),
+	tokenType: text("token_type")
+		.$type<"session_token" | "temp_session_token" | "login_code">()
+		.notNull(),
 	email: text("email").notNull(),
 	userId: int("user_id").references(() => usersTable.id, {
 		onDelete: "cascade",
@@ -62,7 +65,9 @@ export const loginAttemptsTable = sqliteTable("login_attempts_table", {
 	id: int().primaryKey({ autoIncrement: true }),
 	ipAddress: text("ip_address").notNull(),
 	email: text("email"),
-	attemptType: text("attempt_type").notNull(), // 'code_verify' | 'code_send'
+	attemptType: text("attempt_type")
+		.$type<"code_verify" | "code_send">()
+		.notNull(),
 	attemptedAt: int("attempted_at", { mode: "timestamp" }).notNull(),
 	success: int("success", { mode: "boolean" }).notNull().default(false),
 });

--- a/db/seed.ts
+++ b/db/seed.ts
@@ -1,13 +1,13 @@
 import { db } from "./client";
 import { streamingServicesTable } from "./schema";
+import { SUPPORTED_SERVICES } from "@/app/consts";
 
-const streamingServicesSeed = [
-	{ name: "U-NEXT", slug: "unext" },
-	{ name: "Netflix", slug: "netflix" },
-	{ name: "Hulu", slug: "hulu" },
-	{ name: "Disney+", slug: "disney-plus" },
-	{ name: "Prime Video", slug: "prime-video" },
-];
+const streamingServicesSeed = Object.values(SUPPORTED_SERVICES).map(
+	({ name, slug }) => ({
+		name,
+		slug,
+	}),
+);
 
 export const seedStreamingServices = async () => {
 	await db.transaction(async (tx) => {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -45,10 +45,38 @@ export async function verifySessionToken(): Promise<{
 			typeof exp === "number" &&
 			typeof iat === "number"
 		) {
+			const parsedUserId = Number(userId);
+			if (!Number.isFinite(parsedUserId)) {
+				return null;
+			}
+
+			const now = new Date();
+			const [record] = await db
+				.select({
+					userId: authTokensTable.userId,
+					email: authTokensTable.email,
+					deviceId: authTokensTable.deviceId,
+				})
+				.from(authTokensTable)
+				.where(
+					and(
+						eq(authTokensTable.token, sessionToken),
+						eq(authTokensTable.tokenType, "session_token"),
+						eq(authTokensTable.userId, parsedUserId),
+						eq(authTokensTable.email, email),
+						eq(authTokensTable.deviceId, deviceId),
+						gt(authTokensTable.expiresAt, now),
+					),
+				);
+
+			if (!record) {
+				return null;
+			}
+
 			return {
-				userId: Number(userId),
-				email,
-				deviceId,
+				userId: parsedUserId,
+				email: record.email,
+				deviceId: record.deviceId ?? deviceId,
 			};
 		}
 

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -3,13 +3,19 @@ import { loginAttemptsTable } from "@/db/schema";
 import { and, eq, gt, lt } from "drizzle-orm";
 import type { Executor } from "@/db/client";
 
-export async function checkRateLimit(
-	ipAddress: string,
-	attemptType: "code_verify" | "code_send",
-): Promise<{
-	allowed: boolean;
-	remainingAttempts?: number;
-	retryAfter?: Date;
+export async function checkRateLimit({
+	ipAddress,
+	attemptType,
+}: {
+	ipAddress: string;
+	attemptType: "code_verify" | "code_send";
+}): Promise<{
+	limit: {
+		allowed: boolean;
+		remainingAttempts?: number;
+		retryAfter?: Date;
+	};
+	ipAddress: string;
 }> {
 	const now = new Date();
 	const windowStart = new Date(now.getTime() - 15 * 60 * 1000); // 15分
@@ -37,14 +43,20 @@ export async function checkRateLimit(
 		);
 
 		return {
-			allowed: false,
-			retryAfter,
+			limit: {
+				allowed: false,
+				retryAfter,
+			},
+			ipAddress,
 		};
 	}
 
 	return {
-		allowed: true,
-		remainingAttempts: maxAttempts - attempts.length,
+		limit: {
+			allowed: true,
+			remainingAttempts: maxAttempts - attempts.length,
+		},
+		ipAddress,
 	};
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"class-variance-authority": "^0.7.1",
 				"clsx": "^2.1.1",
 				"crypto": "^1.0.1",
-				"dotenv": "^17.2.3",
+				"dotenv": "^17.2.4",
 				"drizzle-orm": "^0.45.1",
 				"jose": "^6.1.3",
 				"lucide-react": "^0.562.0",
@@ -4568,9 +4568,9 @@
 			}
 		},
 		"node_modules/dotenv": {
-			"version": "17.2.3",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
-			"integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+			"version": "17.2.4",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.4.tgz",
+			"integrity": "sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw==",
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=12"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"crypto": "^1.0.1",
-		"dotenv": "^17.2.3",
+		"dotenv": "^17.2.4",
 		"drizzle-orm": "^0.45.1",
 		"jose": "^6.1.3",
 		"lucide-react": "^0.562.0",

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -8,14 +8,14 @@ import {
 	listsTable,
 	usersTable,
 } from "@/db/schema";
+import { SUPPORTED_SERVICES } from "@/app/consts";
 
-export const streamingServicesSeed = [
-	{ name: "U-NEXT", slug: "unext" },
-	{ name: "Netflix", slug: "netflix" },
-	{ name: "Hulu", slug: "hulu" },
-	{ name: "Disney+", slug: "disney-plus" },
-	{ name: "Prime Video", slug: "prime-video" },
-];
+export const streamingServicesSeed = Object.values(SUPPORTED_SERVICES).map(
+	({ name, slug }) => ({
+		name,
+		slug,
+	}),
+);
 
 export async function cleanupTables() {
 	await db.delete(listMoviesTable);


### PR DESCRIPTION
## 概要

モバイル用のリスト登録UIのイベントハンドラでサーバー関数を実行する。

## 変更内容

### リスト登録フォーム

- アクセス時、ログイン中ユーザーのリストIDを取得する関数を追加
- セッショントークンの検証にDBとの称号を追加
- ペースト操作でリスト登録関数を実行
- バリデーションとデバウンス追加 

### サーバー関数

- バリデーションを追加
- 戻り値の型をResultへ変更
- アロー関数をfunctionへ変更
 
### その他リファクタリングなど

- dotenv追加
- 開発中にシーディングできるようにした
- 対応映画サービスのスラッグやドメインを定数化
- カラムへ追加する固定値を型レベルで指定
- 現在時刻は関数外から渡すように修正
- 二重try-catchを改善