### PR TITLE
映画登録のPC用UIをサーバー関数と接続

### DIFF
--- a/app/actions/addMovie.test.ts
+++ b/app/actions/addMovie.test.ts
@@ -82,10 +82,15 @@ describe("addMovie", () => {
 		testListId = list.id;
 	});
 
-	it("Netflix：ジュラシック・パークをリスト追加", async () => {
+	it("【モバイル】Netflix：ジュラシック・パークをリスト追加", async () => {
 		const shareLink = `「 ジュラシック・パーク 」 をNetflix で今 す ぐチ ェ ッ ク\n\nhttps://www.netflix.com/jp/title/60002360?s=i&trkid=258593161&vlang=ja&trg=more`;
 
-		await addMovie(shareLink, testListId);
+		await addMovie({
+			listId: testListId,
+			mobile: {
+				shareLink,
+			},
+		});
 
 		await expectMovieRegistered({
 			title: "ジュラシック・パーク",
@@ -96,10 +101,15 @@ describe("addMovie", () => {
 		});
 	});
 
-	it("U-NEXT：ジュラシック・パークをリスト追加", async () => {
+	it("【モバイル】U-NEXT：ジュラシック・パークをリスト追加", async () => {
 		const shareLink = `「ジュラシック・パーク」をU-NEXTで視聴 https://video-share.unext.jp/video/title/SID0021132?utm_source=com.apple.UIKit.activity.CopyToPasteboard&utm_medium=social&utm_campaign=nonad-sns&rid=PM061312883`;
 
-		await addMovie(shareLink, testListId);
+		await addMovie({
+			listId: testListId,
+			mobile: {
+				shareLink,
+			},
+		});
 
 		await expectMovieRegistered({
 			title: "ジュラシック・パーク",
@@ -110,10 +120,15 @@ describe("addMovie", () => {
 		});
 	});
 
-	it("Hulu：ジュラシック・パークをリスト追加", async () => {
+	it("【モバイル】Hulu：ジュラシック・パークをリスト追加", async () => {
 		const shareLink = `Huluで「ジュラシック･パーク」を視聴中! https://www.hulu.jp/jurassic-park`;
 
-		await addMovie(shareLink, testListId);
+		await addMovie({
+			listId: testListId,
+			mobile: {
+				shareLink,
+			},
+		});
 
 		await expectMovieRegistered({
 			title: "ジュラシック・パーク",
@@ -123,10 +138,15 @@ describe("addMovie", () => {
 		});
 	});
 
-	it("Prime Video：ジュラシック・パークをリスト追加", async () => {
+	it("【モバイル】Prime Video：ジュラシック・パークをリスト追加", async () => {
 		const shareLink = `やあ、ジュラシック・パーク (吹替版)を観ているよ。Prime Videoを今すぐチェックする https://watch.amazon.co.jp/detail?gti=amzn1.dv.gti.7ea9f6d9-bdc8-9b2e-97a9-c341306e36ef&territory=JP&ref_=share_ios_movie&r=web`;
 
-		await addMovie(shareLink, testListId);
+		await addMovie({
+			listId: testListId,
+			mobile: {
+				shareLink,
+			},
+		});
 
 		await expectMovieRegistered({
 			title: "ジュラシック・パーク",
@@ -137,10 +157,104 @@ describe("addMovie", () => {
 		});
 	});
 
-	it("Disney+：ダイナソーをリスト追加", async () => {
+	it("【モバイル】Disney+：ダイナソーをリスト追加", async () => {
 		const shareLink = `https://disneyplus.com/ja/browse/entity-fe34a97c-8f83-4c39-a08e-afc288e14d64?sharesource=iOS Disney+の「ダイナソー」がおすすめなので、チェックしてみてください。`;
 
-		await addMovie(shareLink, testListId);
+		await addMovie({
+			listId: testListId,
+			mobile: {
+				shareLink,
+			},
+		});
+
+		await expectMovieRegistered({
+			title: "ダイナソー",
+			slug: SUPPORTED_SERVICES.DISNEY_PLUS.slug,
+			watchUrl:
+				"https://disneyplus.com/ja/browse/entity-fe34a97c-8f83-4c39-a08e-afc288e14d64?sharesource=iOS",
+			listId: testListId,
+		});
+	});
+
+	it("【PC】Netflix：ジュラシック・パークをリスト追加", async () => {
+		await addMovie({
+			listId: testListId,
+			browser: {
+				title: "ジュラシック・パーク",
+				url: "https://www.netflix.com/jp/title/60002360?s=i&trkid=258593161&vlang=ja&trg=more",
+			},
+		});
+
+		await expectMovieRegistered({
+			title: "ジュラシック・パーク",
+			slug: SUPPORTED_SERVICES.NETFLIX.slug,
+			watchUrl:
+				"https://www.netflix.com/jp/title/60002360?s=i&trkid=258593161&vlang=ja&trg=more",
+			listId: testListId,
+		});
+	});
+
+	it("【PC】U-NEXT：ジュラシック・パークをリスト追加", async () => {
+		await addMovie({
+			listId: testListId,
+			browser: {
+				title: "ジュラシック・パーク",
+				url: "https://video-share.unext.jp/video/title/SID0021132?utm_source=com.apple.UIKit.activity.CopyToPasteboard&utm_medium=social&utm_campaign=nonad-sns&rid=PM061312883",
+			},
+		});
+
+		await expectMovieRegistered({
+			title: "ジュラシック・パーク",
+			slug: SUPPORTED_SERVICES.U_NEXT.slug,
+			watchUrl:
+				"https://video-share.unext.jp/video/title/SID0021132?utm_source=com.apple.UIKit.activity.CopyToPasteboard&utm_medium=social&utm_campaign=nonad-sns&rid=PM061312883",
+			listId: testListId,
+		});
+	});
+
+	it("【PC】Hulu：ジュラシック・パークをリスト追加", async () => {
+		await addMovie({
+			listId: testListId,
+			browser: {
+				title: "ジュラシック・パーク",
+				url: "https://www.hulu.jp/jurassic-park",
+			},
+		});
+
+		await expectMovieRegistered({
+			title: "ジュラシック・パーク",
+			slug: SUPPORTED_SERVICES.HULU.slug,
+			watchUrl: "https://www.hulu.jp/jurassic-park",
+			listId: testListId,
+		});
+	});
+
+	it("【PC】Prime Video：ジュラシック・パークをリスト追加", async () => {
+		await addMovie({
+			listId: testListId,
+			browser: {
+				title: "ジュラシック・パーク",
+				url: "https://watch.amazon.co.jp/detail?gti=amzn1.dv.gti.7ea9f6d9-bdc8-9b2e-97a9-c341306e36ef&territory=JP&ref_=share_ios_movie&r=web",
+			},
+		});
+
+		await expectMovieRegistered({
+			title: "ジュラシック・パーク",
+			slug: SUPPORTED_SERVICES.PRIME_VIDEO.slug,
+			watchUrl:
+				"https://watch.amazon.co.jp/detail?gti=amzn1.dv.gti.7ea9f6d9-bdc8-9b2e-97a9-c341306e36ef&territory=JP&ref_=share_ios_movie&r=web",
+			listId: testListId,
+		});
+	});
+
+	it("【PC】Disney+：ダイナソーをリスト追加", async () => {
+		await addMovie({
+			listId: testListId,
+			browser: {
+				title: "ダイナソー",
+				url: "https://disneyplus.com/ja/browse/entity-fe34a97c-8f83-4c39-a08e-afc288e14d64?sharesource=iOS",
+			},
+		});
 
 		await expectMovieRegistered({
 			title: "ダイナソー",

--- a/app/actions/addMovie.ts
+++ b/app/actions/addMovie.ts
@@ -14,6 +14,7 @@ import type { Tx } from "@/db/client";
 import { SUPPORTED_SERVICES } from "@/app/consts";
 import type { SupportedServiceSlug } from "@/app/consts";
 import { movieShareLinkSchema } from "../movieShareLinkSchema";
+import { movieInfoSchema } from "../movieInfoSchema";
 
 type MovieInfo = {
 	title: string;
@@ -21,12 +22,83 @@ type MovieInfo = {
 	serviceSlug: SupportedServiceSlug;
 };
 
-export async function addMovie(
-	pastedText: string,
-	listId: number,
-): Promise<Result<MovieInfo>> {
-	const result = validateMovieShareLink(pastedText);
+type Args = {
+	listId: number;
+} & (
+	| {
+			mobile: { shareLink: string };
+			browser?: never;
+	  }
+	| {
+			browser: { title: string; url: string };
+			mobile?: never;
+	  }
+);
 
+export async function addMovie({
+	listId,
+	mobile,
+	browser,
+}: Args): Promise<Result<MovieInfo>> {
+	const movieInfoResult = mobile
+		? buildMovieInfoFromMobile(mobile.shareLink)
+		: buildMovieInfoFromBrowser(browser);
+
+	if (!movieInfoResult.success) {
+		return movieInfoResult;
+	}
+
+	const movieInfo = movieInfoResult.data;
+	const streamingServiceId = await findStreamingServiceId(
+		movieInfo.serviceSlug,
+	);
+	if (!streamingServiceId) {
+		return {
+			success: false,
+			error: {
+				message:
+					"ストリーミングサービスを読み取れませんでした。もう一度やり直してください。",
+			},
+		};
+	}
+
+	try {
+		await db.transaction(async (tx) => {
+			const movieId = await findOrCreateMovie(tx, movieInfo.title);
+
+			const movieServiceId = await createMovieService(
+				tx,
+				movieId,
+				streamingServiceId,
+				movieInfo.url,
+			);
+			await createListMovie(tx, listId, movieServiceId);
+		});
+
+		return {
+			success: true,
+			data: movieInfo,
+		};
+	} catch (err) {
+		console.error(err);
+
+		return {
+			success: false,
+			error: { message: "すみませんが、もう一度やり直してください。" },
+		};
+	}
+}
+
+function validateMovieShareLink(shareLink: string) {
+	return movieShareLinkSchema.safeParse({ value: shareLink });
+}
+
+function validateMovieInfo(title: string, url: string) {
+	return movieInfoSchema.safeParse({ title, url });
+}
+
+function buildMovieInfoFromMobile(shareLink: string): Result<MovieInfo> {
+	const result = validateMovieShareLink(shareLink);
 	if (!result.success) {
 		return {
 			success: false,
@@ -34,7 +106,7 @@ export async function addMovie(
 		};
 	}
 
-	const url = extractUrl(pastedText);
+	const url = extractUrl(shareLink);
 	if (!url) {
 		return {
 			success: false,
@@ -64,7 +136,7 @@ export async function addMovie(
 		};
 	}
 
-	const movieInfo = buildMovieInfo(url, matcher, pastedText);
+	const movieInfo = buildMovieInfo(url, matcher, shareLink);
 	if (!movieInfo) {
 		return {
 			success: false,
@@ -74,48 +146,55 @@ export async function addMovie(
 		};
 	}
 
-	const streamingServiceId = await findStreamingServiceId(
-		movieInfo.serviceSlug,
-	);
-	if (!streamingServiceId) {
-		return {
-			success: false,
-			error: {
-				message:
-					"ストリーミングサービスを読み取れませんでした。もう一度やり直してください。",
-			},
-		};
-	}
+	return { success: true, data: movieInfo };
+}
 
-	try {
-		await db.transaction(async (tx) => {
-			const movieId = await findOrCreateMovie(tx, movieInfo.title);
-
-			const movieServiceId = await createMovieService(
-				tx,
-				movieId,
-				streamingServiceId,
-				movieInfo.url,
-			);
-			await createListMovie(tx, listId, movieServiceId);
-		});
-	} catch (err) {
-		console.error(err);
-
+function buildMovieInfoFromBrowser(
+	browser: { title: string; url: string } | undefined,
+): Result<MovieInfo> {
+	if (!browser) {
 		return {
 			success: false,
 			error: { message: "すみませんが、もう一度やり直してください。" },
 		};
 	}
 
+	const result = validateMovieInfo(browser.title, browser.url);
+	if (!result.success) {
+		return {
+			success: false,
+			error: { message: "もう一度やり直してください。" },
+		};
+	}
+
+	const hostname = parseHostname(browser.url);
+	if (!hostname) {
+		return {
+			success: false,
+			error: {
+				message: "URLを読み取れませんでした。もう一度やり直してください。",
+			},
+		};
+	}
+
+	const matcher = findMatcher(hostname);
+	if (!matcher) {
+		return {
+			success: false,
+			error: {
+				message: "URLを読み取れませんでした。もう一度やり直してください。",
+			},
+		};
+	}
+
 	return {
 		success: true,
-		data: movieInfo,
+		data: {
+			title: normalizeTitle(browser.title),
+			url: browser.url,
+			serviceSlug: matcher.slug,
+		},
 	};
-}
-
-function validateMovieShareLink(shareLink: string) {
-	return movieShareLinkSchema.safeParse({ value: shareLink });
 }
 
 type ServiceMatcher = {

--- a/app/movieInfoSchema.ts
+++ b/app/movieInfoSchema.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import { SUPPORTED_SERVICES } from "@/app/consts";
+
+const parseHostname = (url: string): string | null => {
+	try {
+		return new URL(url).hostname;
+	} catch {
+		return null;
+	}
+};
+
+const isSupportedHost = (hostname: string): boolean => {
+	return Object.values(SUPPORTED_SERVICES).some((service) => {
+		return (
+			hostname === service.hostname ||
+			hostname.endsWith(`.${service.hostname}`)
+		);
+	});
+};
+
+export const movieInfoSchema = z.object({
+	title: z.string().min(1, "作品タイトルを入力してください。"),
+	url: z
+		.string()
+		.min(1, "視聴URLを入力してください。")
+		.pipe(z.url({ message: "URLの形式で入力してください。" }))
+		.refine((val) => {
+			const hostname = parseHostname(val);
+			if (!hostname) return false;
+			return isSupportedHost(hostname);
+		}, "対応していないサービスのリンクです。"),
+});

--- a/components/MovieInputForm/MobileForm/MobileFormTextarea/index.tsx
+++ b/components/MovieInputForm/MobileForm/MobileFormTextarea/index.tsx
@@ -28,7 +28,12 @@ export default function MobileFormTextarea({ listId }: Props) {
 	const handleListRegistration = useCallback(
 		async (shareLink: string) => {
 			if (listId === null) return;
-			const data = await addMovie(shareLink, listId);
+			const data = await addMovie({
+				listId,
+				mobile: {
+					shareLink,
+				},
+			});
 		},
 		[listId],
 	);

--- a/components/MovieInputForm/PcForm/index.tsx
+++ b/components/MovieInputForm/PcForm/index.tsx
@@ -1,11 +1,74 @@
+"use client";
+
+import type z from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useCallback, useEffect, useRef } from "react";
+import { useForm, useWatch } from "react-hook-form";
 import Form from "@/components/MovieInputForm/Form";
+import { movieInfoSchema } from "@/app/movieInfoSchema";
+import { addMovie } from "@/app/actions/addMovie";
 
 type Props = {
 	listId: number | null;
 };
 
 export default function PcForm({ listId }: Props) {
-	void listId;
+	const {
+		register,
+		formState: { errors },
+		control,
+		trigger,
+	} = useForm<z.infer<typeof movieInfoSchema>>({
+		resolver: zodResolver(movieInfoSchema),
+		mode: "onChange",
+	});
+
+	const handleSubmit = useCallback(
+		async (title: string, url: string) => {
+			if (listId === null) return;
+			const data = await addMovie({
+				listId,
+				browser: {
+					title,
+					url,
+				},
+			});
+			console.log(data)
+		},
+		[listId],
+	);
+
+	const title = useWatch({ control, name: "title" });
+	const url = useWatch({ control, name: "url" });
+	const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		if (title === undefined || url === undefined) return;
+		let canceled = false;
+
+		const run = async () => {
+			const isValid = await trigger(["title", "url"]);
+			if (!isValid || canceled) return;
+
+			if (debounceRef.current) {
+				clearTimeout(debounceRef.current);
+			}
+
+			debounceRef.current = setTimeout(() => {
+				void handleSubmit(title, url);
+			}, 400);
+		};
+
+		void run();
+
+		return () => {
+			canceled = true;
+			if (debounceRef.current) {
+				clearTimeout(debounceRef.current);
+			}
+		};
+	}, [title, url, trigger, handleSubmit]);
+
 	return (
 		<div className="w-full md:px-10 flex flex-col justify-center items-center">
 			<div className="w-full flex flex-col gap-4">
@@ -13,13 +76,23 @@ export default function PcForm({ listId }: Props) {
 					<div className="text-foreground-dark-2 flex justify-center py-2 font-medium">
 						作品のタイトル・視聴URLを入力
 					</div>
-					<Form placeholder="ジュラシック・パーク" id="title" name="title" />
+					<Form
+						placeholder="ジュラシック・パーク"
+						id="title"
+						{...register("title")}
+					/>
+					{errors.title && (
+						<p className="text-sm text-red-500">{errors.title.message}</p>
+					)}
 					<Form
 						className="min-h-[3lh] break-all"
 						placeholder="https://www.netflix.com/jp/title/60002360?s=i&trkid=258593161&vlang=ja&trg=cp"
 						id="watch-url"
-						name="watch-url"
+						{...register("url")}
 					/>
+					{errors.url && (
+						<p className="text-sm text-red-500">{errors.url.message}</p>
+					)}
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## 概要

モバイル用のフォームでのみリスト登録を実装していた。
PCのフォームでも登録できるよう実装を変更。

## 変更内容
- サーバー関数の仕様を変更。「タイトル・URL」と「共有リンク」それぞれの引数に両対応。
- PC用入力フォームのバリデーションルールを追加
- PC用入力フォームにバリデーションを追加
- デバウンス＋サーバー関数へ送信