### PR TITLE
ログインコード6桁の検証ロジックを修正

### DIFF
--- a/app/actions/addMovie.ts
+++ b/app/actions/addMovie.ts
@@ -31,9 +31,28 @@ export async function addMovie({
 	mobile,
 	browser,
 }: Args): Promise<Result<MovieInfo, MovieFormError>> {
+	if (mobile) {
+		const result = movieShareLinkSchema.safeParse({ value: mobile.shareLink });
+		if (!result.success) {
+			return {
+				success: false,
+				error: result.error,
+			};
+		}
+	} else if (browser) {
+		const { title, url } = browser;
+		const result = movieInfoSchema.safeParse({ title, url });
+		if (!result.success) {
+			return {
+				success: false,
+				error: result.error,
+			};
+		}
+	}
+
 	const movieInfoResult = mobile
 		? buildMovieInfoFromMobile(mobile.shareLink)
-		: buildMovieInfoFromBrowser(browser);
+		: buildMovieInfoFromBrowser({ title: browser.title, url: browser.url });
 
 	if (!movieInfoResult.success) {
 		return movieInfoResult;
@@ -51,6 +70,7 @@ export async function addMovie({
 	const streamingServiceId = await findStreamingServiceId(
 		movieInfo.serviceSlug,
 	);
+
 	if (!streamingServiceId) {
 		return {
 			success: false,
@@ -85,25 +105,9 @@ export async function addMovie({
 	};
 }
 
-function validateMovieShareLink(shareLink: string) {
-	return movieShareLinkSchema.safeParse({ value: shareLink });
-}
-
-function validateMovieInfo(title: string, url: string) {
-	return movieInfoSchema.safeParse({ title, url });
-}
-
 function buildMovieInfoFromMobile(
 	shareLink: string,
 ): Result<MovieInfo, MovieFormError> {
-	const result = validateMovieShareLink(shareLink);
-	if (!result.success) {
-		return {
-			success: false,
-			error: result.error,
-		};
-	}
-
 	const url = extractUrl(shareLink);
 	if (!url) {
 		return {
@@ -132,25 +136,14 @@ function buildMovieInfoFromMobile(
 	return { success: true, data: movieInfo };
 }
 
-function buildMovieInfoFromBrowser(
-	browser: { title: string; url: string } | undefined,
-): Result<MovieInfo, MovieFormError> {
-	if (!browser) {
-		return {
-			success: false,
-			error: { message: "すみませんが、もう一度やり直してください。" },
-		};
-	}
-
-	const result = validateMovieInfo(browser.title, browser.url);
-	if (!result.success) {
-		return {
-			success: false,
-			error: result.error,
-		};
-	}
-
-	const matcherResult = resolveMatcherFromUrl(browser.url);
+function buildMovieInfoFromBrowser({
+	title,
+	url,
+}: {
+	title: string;
+	url: string;
+}): Result<MovieInfo, MovieFormError> {
+	const matcherResult = resolveMatcherFromUrl(url);
 	if (!matcherResult.success) {
 		return matcherResult;
 	}
@@ -158,8 +151,8 @@ function buildMovieInfoFromBrowser(
 	return {
 		success: true,
 		data: {
-			title: normalizeTitle(browser.title),
-			url: browser.url,
+			title: normalizeTitle(title),
+			url: url,
 			serviceSlug: matcherResult.data.slug,
 			serviceName: matcherResult.data.name,
 		},

--- a/app/login/actions/sendLoginCode.ts
+++ b/app/login/actions/sendLoginCode.ts
@@ -2,7 +2,7 @@
 
 import { headers } from "next/headers";
 import { eq, and } from "drizzle-orm";
-import crypto from "crypto";
+import crypto from "node:crypto";
 import { Resend } from "resend";
 import { checkRateLimit, recordAttempt } from "@/lib/rateLimit";
 import type { Result } from "@/app/types/Result";

--- a/app/login/actions/verifyLoginCode.test.ts
+++ b/app/login/actions/verifyLoginCode.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "@/db/client";
+import type { Tx } from "@/db/client";
+import {
+	authTokensTable,
+	loginAttemptsTable,
+	usersTable,
+} from "@/db/schema";
+import { verifyLoginCode } from "./verifyLoginCode";
+import { createHash, randomInt } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+
+const { mockSetCookie, mockCookies, mockHeaders } = vi.hoisted(() => {
+	const setCookie = vi.fn();
+	const cookies = vi.fn(async () => ({
+		set: setCookie,
+	}));
+	const headers = vi.fn(async () => ({
+		get: (name: string) => {
+			if (name === "x-forwarded-for") {
+				return "127.0.0.1";
+			}
+			if (name === "user-agent") {
+				return "vitest-agent";
+			}
+			return null;
+		},
+	}));
+
+	return {
+		mockSetCookie: setCookie,
+		mockCookies: cookies,
+		mockHeaders: headers,
+	};
+});
+
+const { mockGenerateTempSessionToken } = vi.hoisted(() => {
+	return {
+		mockGenerateTempSessionToken: vi.fn(() => "mock-temp-session-token"),
+	};
+});
+
+vi.mock("next/headers", () => ({
+	cookies: mockCookies,
+	headers: mockHeaders,
+}));
+
+vi.mock("@/lib/auth", () => ({
+	generateSessionToken: vi.fn(async () => "mock-session-token"),
+	generateTempSessionToken: mockGenerateTempSessionToken,
+	addDays: vi.fn((date: Date, days: number) => {
+		return new Date(date.getTime() + days * 24 * 60 * 60 * 1000);
+	}),
+}));
+
+function generateLoginCode() {
+	return randomInt(100000, 1000000).toString();
+}
+
+function hashLoginCode(code: string) {
+	return createHash("sha256").update(code).digest("hex");
+}
+
+async function insertLoginCode({
+	tx,
+	email,
+	token,
+	expiresAt,
+	createdAt,
+}: {
+	tx: Tx;
+	email: string;
+	token: string;
+	expiresAt: Date;
+	createdAt: Date;
+}) {
+	const [user] = await tx
+		.select()
+		.from(usersTable)
+		.where(eq(usersTable.email, email));
+
+	await tx.insert(authTokensTable).values({
+		token,
+		tokenType: "login_code",
+		email,
+		userId: user?.id ?? null,
+		expiresAt,
+		createdAt,
+	});
+}
+
+describe("verifyLoginCode", () => {
+	const now = new Date("2026-02-16T00:00:00.000Z");
+	const email = "verify-login-code-test@example.com";
+	let loginCode = "";
+
+	beforeEach(async () => {
+		mockSetCookie.mockReset();
+		mockGenerateTempSessionToken.mockReset();
+		mockGenerateTempSessionToken.mockReturnValue("mock-temp-session-token");
+		await db.delete(loginAttemptsTable);
+		await db.delete(authTokensTable);
+		await db.insert(usersTable).values({
+			publicId: "verify-login-code-test-user",
+			email,
+		});
+
+		loginCode = generateLoginCode();
+
+		await db.transaction(async (tx) => {
+			await insertLoginCode({
+				tx,
+				email,
+				token: hashLoginCode(loginCode),
+				expiresAt: new Date(now.getTime() + 10 * 60 * 1000),
+				createdAt: now,
+			});
+		});
+	});
+
+	it("事前投入したログインコードを検証できる", async () => {
+		const result = await verifyLoginCode(loginCode, now);
+
+		expect(result.success).toBe(true);
+		if (!result.success) {
+			return;
+		}
+
+		expect(result.data.email).toBe(email);
+		expect(result.data.isNewUser).toBe(false);
+		expect(mockSetCookie).toHaveBeenCalledTimes(1);
+		expect(mockSetCookie).toHaveBeenCalledWith(
+			"session_token",
+			expect.any(String),
+			expect.objectContaining({
+				httpOnly: true,
+				sameSite: "lax",
+			}),
+		);
+	});
+
+	it("新規ユーザー分岐を通る", async () => {
+		const newUserEmail = "verify-login-code-new-user@example.com";
+		const newUserLoginCode = generateLoginCode();
+
+		await db.transaction(async (tx) => {
+			await insertLoginCode({
+				tx,
+				email: newUserEmail,
+				token: hashLoginCode(newUserLoginCode),
+				expiresAt: new Date(now.getTime() + 10 * 60 * 1000),
+				createdAt: now,
+			});
+		});
+
+		await verifyLoginCode(newUserLoginCode, now);
+
+		expect(mockGenerateTempSessionToken).toHaveBeenCalledTimes(1);
+
+		expect(mockSetCookie).toHaveBeenCalledTimes(1);
+		expect(mockSetCookie).toHaveBeenCalledWith(
+			"temp_session_token",
+			"mock-temp-session-token",
+			expect.objectContaining({
+				httpOnly: true,
+				sameSite: "lax",
+			}),
+		);
+
+		const [tempToken] = await db
+			.select()
+			.from(authTokensTable)
+			.where(
+				and(
+					eq(authTokensTable.email, newUserEmail),
+					eq(authTokensTable.tokenType, "temp_session_token"),
+					eq(authTokensTable.token, "mock-temp-session-token"),
+				),
+			);
+
+		expect(tempToken).toBeDefined();
+		expect(tempToken.userId).toBeNull();
+	});
+});

--- a/app/login/actions/verifyLoginCode.ts
+++ b/app/login/actions/verifyLoginCode.ts
@@ -2,7 +2,7 @@
 
 import type { Result } from "@/app/types/Result";
 import { cookies, headers } from "next/headers";
-import crypto from "crypto";
+import crypto from "node:crypto";
 import { eq, and, gt } from "drizzle-orm";
 import { db } from "@/db/client";
 import type { Tx } from "@/db/client";
@@ -129,10 +129,12 @@ export async function verifyLoginCode(
 
 				const tempToken = generateTempSessionToken();
 
+				const expiresAt = addMinutes(now, 15);
+
 				await insertTempToken({
 					tx,
-					tempToken: generateTempSessionToken(),
-					expiresAt: addMinutes(now, 15),
+					tempToken,
+					expiresAt,
 					email: founded.email,
 					deviceId,
 					createdAt: now,

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,6 +1,6 @@
 import { cookies } from "next/headers";
 import { jwtVerify, SignJWT } from "jose";
-import crypto from "crypto";
+import crypto from "node:crypto";
 import { db } from "@/db/client";
 import { authTokensTable } from "@/db/schema";
 import { and, eq, gt } from "drizzle-orm";
@@ -21,7 +21,6 @@ export async function verifySessionToken(): Promise<{
 	try {
 		const cookieStore = await cookies();
 		const sessionToken = cookieStore.get("session_token")?.value;
-
 		if (!sessionToken) {
 			return null;
 		}

--- a/lib/devices.ts
+++ b/lib/devices.ts
@@ -1,4 +1,4 @@
-import crypto from "crypto";
+import crypto from "node:crypto";
 
 export function generateDeviceId(userAgent: string) {
 	return crypto

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,5 +9,6 @@ export default defineConfig({
 		environment: "jsdom",
 		env: dotenv.config({ path: ".env.test" }).parsed,
 		setupFiles: ["./tests/helpers/setup.ts"],
+		maxWorkers: 1,
 	},
 });


### PR DESCRIPTION
## 概要

ログインコード入力後の検証に失敗していた。

原因は新規ユーザーの登録時、未定義の変数へアクセスしてしまっていたこと。
（型検査にも引っかかっていなかった）

この問題を修正し、動作を確認した。

## 変更内容

### ログインコード検証の処理へ正常系のテストコードを追加
`app/login/actions/verifyLoginCode.test.ts`を作成
ログインコード検証＋新規ユーザー登録の正常系テストを実装

### vitestを並列実行から直列実行へ変更

並列に実行されるテストから同一のDBへ接続すると排他ロックが競合する。
本質的にはその問題を解消すべきだが、現在はテストコード自体がかなり少ないので優先度を下げる。
そのため暫定対応として直列での実行へ変更した。

feat: ログインコード検証のテストコード

### cryptoを明示的にnodeのモジュールとしてimport
テスト実行時の解決のため