### PR TITLE
映画リスト画面のマークアップ

### DIFF
--- a/app/actions/getUserMovieListId.ts
+++ b/app/actions/getUserMovieListId.ts
@@ -4,7 +4,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import { listsTable } from "@/db/schema";
 
-export async function getUserMovieList(userId: number): Promise<number | null> {
+export async function getUserMovieListId(userId: number): Promise<number | null> {
 	const [list] = await db
 		.select({ id: listsTable.id })
 		.from(listsTable)

--- a/app/list/actions/getUserMovieList.ts
+++ b/app/list/actions/getUserMovieList.ts
@@ -1,0 +1,36 @@
+"use server";
+
+import { desc, eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import {
+	listsTable,
+	listMoviesTable,
+	movieServicesTable,
+	moviesTable,
+	streamingServicesTable,
+} from "@/db/schema";
+
+export async function getUserMovieList(userId: number) {
+	const movies = await db
+		.select({
+			title: moviesTable.title,
+			watchUrl: movieServicesTable.watchUrl,
+			serviceSlug: streamingServicesTable.slug,
+			serviceName: streamingServicesTable.name,
+		})
+		.from(listsTable)
+		.innerJoin(listMoviesTable, eq(listMoviesTable.listId, listsTable.id))
+		.innerJoin(
+			movieServicesTable,
+			eq(movieServicesTable.id, listMoviesTable.movieServiceId),
+		)
+		.innerJoin(moviesTable, eq(moviesTable.id, movieServicesTable.movieId))
+		.innerJoin(
+			streamingServicesTable,
+			eq(streamingServicesTable.id, movieServicesTable.streamingServiceId),
+		)
+		.where(eq(listsTable.userId, userId))
+		.orderBy(desc(listMoviesTable.id));
+
+	return movies;
+}

--- a/app/list/components/List/Item/Card/index.tsx
+++ b/app/list/components/List/Item/Card/index.tsx
@@ -1,0 +1,20 @@
+import type { SupportedServiceName } from "@/app/consts";
+
+export default function ListItemCard({
+	title,
+	serviceName,
+}: {
+	title: string;
+	serviceName: SupportedServiceName;
+}) {
+	return (
+		<div className="border border-background-light-2 rounded-lg pb-2">
+			<div className="w-full bg-background-dark-1 rounded-tl-lg rounded-tr-lg aspect-3/1"></div>
+
+			<div className="px-2">
+				<span className="text-xs">{serviceName}</span>
+				<h3>{title}</h3>
+			</div>
+		</div>
+	);
+}

--- a/app/list/components/List/Item/Detail/index.tsx
+++ b/app/list/components/List/Item/Detail/index.tsx
@@ -1,0 +1,43 @@
+import type { SupportedServiceName } from "@/app/consts";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+	DialogDescription,
+} from "@/components/ui/dialog";
+import ListItemCard from "../Card";
+
+export default function ListItemDetail({
+	title,
+	serviceName,
+	watchUrl,
+}: {
+	title: string;
+	serviceName: SupportedServiceName;
+	watchUrl: string;
+}) {
+	return (
+		<Dialog>
+			<DialogTrigger asChild>
+				<ListItemCard title={title} serviceName={serviceName} />
+			</DialogTrigger>
+			<DialogContent className="p-0 max-w-[calc(100%-1rem)] sm:max-w-[40%]">
+				<DialogHeader className="w-full gap-0 text-left">
+					<div className="w-full bg-background-dark-1 rounded-tl-lg rounded-tr-lg aspect-3/1"></div>
+
+					<div className="px-4">
+						<span className="p-2 block">{serviceName}</span>
+						<DialogTitle className="text-left">
+							<a href={watchUrl} target="_blank" rel="noopener noreferrer">
+								{title}
+							</a>
+						</DialogTitle>
+					</div>
+				</DialogHeader>
+				<DialogDescription></DialogDescription>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/app/list/components/List/Item/ServiceName/index.tsx
+++ b/app/list/components/List/Item/ServiceName/index.tsx
@@ -1,0 +1,12 @@
+import type { SupportedServiceSlug, SupportedServiceName } from "@/app/consts";
+export default function ServiceName({
+	serviceSlug,
+	serviceName,
+}: {
+	serviceSlug: SupportedServiceSlug;
+	serviceName: SupportedServiceName;
+}) {
+    // TODO：serviceSlug で背景色を切り替える
+    // デザインの調整ができたらサービスごとの色を決める
+	return <span className="bg-background">{serviceName}</span>;
+}

--- a/app/list/components/List/Title/index.tsx
+++ b/app/list/components/List/Title/index.tsx
@@ -1,0 +1,3 @@
+export default function ListItemTitle({ title }: { title: string }) {
+	return <h2>{title}</h2>;
+}

--- a/app/list/page.tsx
+++ b/app/list/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from "next/navigation";
+import { isAuthenticated } from "@/lib/auth";
+import { getUserMovieList } from "./actions/getUserMovieList";
+import ListItemDetail from "./components/List/Item/Detail";
+
+export default async function MovieList() {
+	const isVerified = await isAuthenticated();
+
+	if (!isVerified) {
+		redirect("/login");
+	}
+
+	const userMovieList = await getUserMovieList(isVerified.userId);
+
+	return (
+		<main className="max-w-240 mx-auto pt-10 pb-4">
+			{userMovieList.length ? (
+			<div className="grid grid-cols-1 sm:grid-cols-3 gap-4 px-4 sm:px-0">
+				{userMovieList.map((movie, index) => (
+					<div key={`${index}-${movie.title}`}>
+						<ListItemDetail
+							title={movie.title}
+							serviceName={movie.serviceName}
+							watchUrl={movie.watchUrl}
+						/>
+					</div>
+				))}
+			</div>
+			): (
+				<div>観たい作品をここへ集めましょう！</div>
+			)}
+		</main>
+	);
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,11 @@
 import { headers } from "next/headers";
-import { verifySessionToken } from "@/lib/auth";
-import { getUserMovieList } from "@/app/actions/getUserMovieListId";
+import { getUserMovieListId } from "@/app/actions/getUserMovieListId";
 import MovieInputForm from "./components/MovieInputForm";
+import { isAuthenticated } from "@/lib/auth";
 
 export default async function Home() {
-	const isVerified = await verifySessionToken();
-	const listId = isVerified ? await getUserMovieList(isVerified.userId) : null;
+	const isVerified = await isAuthenticated();
+	const listId = isVerified ? await getUserMovieListId(isVerified.userId) : null;
 
 	const headersList = await headers();
 	const userAgent = headersList.get("user-agent") || "";

--- a/app/register/actions/registerUser.ts
+++ b/app/register/actions/registerUser.ts
@@ -13,15 +13,19 @@ import { verifyTempSessionToken } from "@/lib/auth";
 export async function registerUser({
 	email,
 	userId,
+	tempToken,
+	now,
 }: {
 	email: string;
 	userId: string;
+	tempToken: string;
+	now: Date;
 }): Promise<
 	Result<{
 		userId: string;
 	}>
 > {
-	const tempSession = await verifyTempSessionToken();
+	const tempSession = await verifyTempSessionToken({ tempToken, now });
 
 	if (!tempSession) {
 		return {
@@ -49,8 +53,6 @@ export async function registerUser({
 	const headersList = await headers();
 	const userAgent = headersList.get("user-agent") || "Unknown";
 	const deviceId = generateDeviceId(userAgent);
-
-	const now = new Date();
 
 	try {
 		const newUserId = await db.transaction(async (tx) => {

--- a/app/register/components/RegisterForm/index.tsx
+++ b/app/register/components/RegisterForm/index.tsx
@@ -15,9 +15,10 @@ type UserIdFormData = z.infer<typeof userIdSchema>;
 
 type Props = {
 	email: string;
+	token: string;
 };
 
-export default function RegstarForm({ email }: Props) {
+export default function RegistarForm({ email, token }: Props) {
 	const [isCheckingDuplicate, setIsCheckingDuplicate] = useState(false);
 	const [isDuplicate, setIsDuplicate] = useState(false);
 	const [serverErrorMessage, setServerErrorMessage] = useState<string>("");
@@ -74,7 +75,14 @@ export default function RegstarForm({ email }: Props) {
 	}, []);
 
 	const onSubmit = async (data: UserIdFormData) => {
-		const result = await registerUser({ userId: data.userId, email });
+
+
+		const result = await registerUser({
+			userId: data.userId,
+			email,
+			tempToken: token,
+			now: new Date(),
+		});
 		if (result.success) {
 			return redirect("/");
 		}

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,18 +1,25 @@
 import { redirect } from "next/navigation";
+import { cookies } from "next/headers";
 import FormContainer from "@/components/FormContainer";
-import RegstarForm from "./components/RegisterForm";
+import RegistarForm from "./components/RegisterForm";
 import { verifyTempSessionToken } from "@/lib/auth";
 
 export default async function RegstarPage() {
-	const tempSession = await verifyTempSessionToken();
+	const cookieStore = await cookies();
+	const tempToken = cookieStore.get("temp_session_token")?.value;
 
-	if (!tempSession) {
+	const tempSession = await verifyTempSessionToken({
+		tempToken,
+		now: new Date(),
+	});
+
+	if (!tempSession || !tempToken) {
 		return redirect("/");
 	}
 
 	return (
 		<FormContainer>
-			<RegstarForm email={tempSession.email} />
+			<RegistarForm token={tempToken} email={tempSession.email} />
 		</FormContainer>
 	);
 }

--- a/lib/auth.test.ts
+++ b/lib/auth.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { db } from "@/db/client";
+import { authTokensTable, usersTable } from "@/db/schema";
+import {
+	generateSessionToken,
+	generateTempSessionToken,
+	verifySessionToken,
+	verifyTempSessionToken,
+} from "./auth";
+import { eq } from "drizzle-orm";
+
+describe("auth token verification", () => {
+	const now = new Date("2026-02-16T00:00:00.000Z");
+
+	beforeEach(async () => {
+		await db.delete(authTokensTable);
+		await db.delete(usersTable);
+	});
+
+	it("有効な認証トークンを検証できる", async () => {
+		const email = "verify-session-token-test@example.com";
+		const deviceId = "test-device-id";
+
+		await db.insert(usersTable).values({
+			publicId: "verify-session-token-test-user",
+			email,
+		});
+
+		const [user] = await db
+			.select({ id: usersTable.id })
+			.from(usersTable)
+			.where(eq(usersTable.email, email));
+
+		expect(user).toBeDefined();
+		if (!user) {
+			return;
+		}
+
+		const sessionToken = await generateSessionToken({
+			userId: user.id,
+			email,
+			deviceId,
+		});
+
+		await db.insert(authTokensTable).values({
+			token: sessionToken,
+			tokenType: "session_token",
+			email,
+			userId: user.id,
+			deviceId,
+			expiresAt: new Date(now.getTime() + 10 * 60 * 1000),
+			createdAt: now,
+		});
+
+		const result = await verifySessionToken({ sessionToken, now });
+
+		expect(result).toStrictEqual({
+			userId: user.id,
+			email,
+			deviceId,
+		});
+	});
+
+	it("有効な仮認証トークンを検証できる", async () => {
+		const email = "verify-temp-session-token-test@example.com";
+		const tempToken = generateTempSessionToken();
+
+		await db.insert(authTokensTable).values({
+			token: tempToken,
+			tokenType: "temp_session_token",
+			email,
+			expiresAt: new Date(now.getTime() + 10 * 60 * 1000),
+			createdAt: now,
+		});
+
+		const result = await verifyTempSessionToken({
+			tempToken,
+			now,
+		});
+
+		expect(result).toStrictEqual({ email });
+	});
+});

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,30 +1,26 @@
-import { cookies } from "next/headers";
 import { jwtVerify, SignJWT } from "jose";
 import crypto from "node:crypto";
 import { db } from "@/db/client";
 import { authTokensTable } from "@/db/schema";
 import { and, eq, gt } from "drizzle-orm";
+import { cookies } from "next/headers";
 
-function getSecretKey(): Uint8Array {
-	const secret = process.env.JWT_SECRET;
-	if (!secret) {
-		throw new Error("JWT_SECRET is not defined");
-	}
-	return new TextEncoder().encode(secret);
-}
-
-export async function verifySessionToken(): Promise<{
+export async function verifySessionToken({
+	sessionToken,
+	now,
+}: {
+	sessionToken?: string;
+	now: Date;
+}): Promise<{
 	userId: number;
 	email: string;
 	deviceId: string;
 } | null> {
-	try {
-		const cookieStore = await cookies();
-		const sessionToken = cookieStore.get("session_token")?.value;
-		if (!sessionToken) {
-			return null;
-		}
+	if (!sessionToken) {
+		return null;
+	}
 
+	try {
 		const secretKey = getSecretKey();
 		const { payload } = await jwtVerify(sessionToken, secretKey, {
 			algorithms: ["HS256"],
@@ -49,7 +45,6 @@ export async function verifySessionToken(): Promise<{
 				return null;
 			}
 
-			const now = new Date();
 			const [record] = await db
 				.select({
 					userId: authTokensTable.userId,
@@ -86,18 +81,20 @@ export async function verifySessionToken(): Promise<{
 	}
 }
 
-export async function verifyTempSessionToken(): Promise<{
+export async function verifyTempSessionToken({
+	tempToken,
+	now,
+}: {
+	tempToken?: string;
+	now: Date;
+}): Promise<{
 	email: string;
 } | null> {
+	if (!tempToken) {
+		return null;
+	}
+
 	try {
-		const cookieStore = await cookies();
-		const tempToken = cookieStore.get("temp_session_token")?.value;
-
-		if (!tempToken) {
-			return null;
-		}
-
-		const now = new Date();
 		const [record] = await db
 			.select({
 				email: authTokensTable.email,
@@ -122,9 +119,24 @@ export async function verifyTempSessionToken(): Promise<{
 	}
 }
 
-export async function isAuthenticated(): Promise<boolean> {
-	const payload = await verifySessionToken();
-	return payload !== null;
+export async function isAuthenticated() {
+	const cookieStore = await cookies();
+	const sessionToken = cookieStore.get("session_token")?.value;
+
+	const payload = await verifySessionToken({
+		sessionToken,
+		now: new Date(),
+	});
+
+	return payload;
+}
+
+function getSecretKey(): Uint8Array {
+	const secret = process.env.JWT_SECRET;
+	if (!secret) {
+		throw new Error("JWT_SECRET is not defined");
+	}
+	return new TextEncoder().encode(secret);
 }
 
 export async function generateSessionToken({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,6 @@ import dotenv from "dotenv";
 export default defineConfig({
 	plugins: [tsconfigPaths(), react()],
 	test: {
-		environment: "jsdom",
 		env: dotenv.config({ path: ".env.test" }).parsed,
 		setupFiles: ["./tests/helpers/setup.ts"],
 		maxWorkers: 1,


### PR DESCRIPTION
## 概要

ユーザーが登録した映画を一覧表示するページを追加。
ログインユーザーのみがアクセスするページであることから認証系ロジックのリファクタリングとテストコードの実装を行なった。

## 変更内容

### トークンの検証ロジックへテストを追加
リファクタリング時の動作確認として、正規・仮トークンそれぞれへ正常系のテストケースのみ追加。

### テストの実行環境を`jsdom`から`node`（デフォルト）へ変更

JWTの検証に使っている`jose`を呼び出しているため、`jsdom`環境では認証ロジックを実行できない。
DOMに依存したテストは実装の予定がないため、テスト全体を`node`で実行するよう設定を変更。

### トークンの検証関数の現在日時・Cookieの参照を引数にして外部化
これまで認証ロジック内でCookieのトークンを取得・現在日時のDateオブジェクトを生成していた。
テスタブルにするため、関数としての純粋さを高める目的でこれらを引数で受け渡すよう変更。

### ユーザーのリスト取得関数
ユーザーIDを受け取って映画情報の配列を返すサーバー関数を追加。

### 映画リスト画面のマークアップ
サーバー関数で取得した配列を`map`で表示するページを追加。

- CookieからユーザーIDを取得してサーバー関数を実行。
- リスト内の各作品はクリックで詳細のダイアログを表示。
- 未ログインの場合はログインページへリダイレクト。