### PR TITLE
DBとローカルいずれにもリストがなければローカルへ新規作成するロジックを追加

### DIFF
--- a/app/[publicListId]/page.tsx
+++ b/app/[publicListId]/page.tsx
@@ -16,9 +16,5 @@ export default async function MovieList({ params }: Props) {
 	}
 	const { publicListId } = await params;
 
-	return (
-		<main className="max-w-240 mx-auto pt-10 pb-4 ">
-			<UserMovieList publicListId={publicListId} />
-		</main>
-	);
+	return <UserMovieList publicListId={publicListId} />;
 }

--- a/app/components/MovieCard/index.tsx
+++ b/app/components/MovieCard/index.tsx
@@ -89,7 +89,7 @@ export default function MovieCard({ movie, listPublicId, onSuccess }: Props) {
 	}, [isSubmitSuccess, isRemoveSuccess, onSuccess, setMovie]);
 
 	const handleSearchSelect = (externalMovieId: number) => {
-		const list = store.get(risutopottoAtom).movie_service;
+		const list = store.get(risutopottoAtom).list.items;
 		const hasSameDetails = list.find(
 			(item) => item.details?.externalDatabaseMovieId === externalMovieId,
 		);

--- a/app/components/MovieInputForm/index.tsx
+++ b/app/components/MovieInputForm/index.tsx
@@ -32,7 +32,7 @@ export default function MovieInputForm({
 		userAgent,
 	});
 
-	const { hydrateLocalStorageFromDb, getMovieService } = useLocalStorage();
+	const { ensureLocalList } = useLocalStorage();
 
 	const [extractedMovie, setExtractedMovie] = useState<ListItem | null>(null);
 
@@ -55,20 +55,12 @@ export default function MovieInputForm({
 
 			setExtractedMovie(extracted);
 
-			const movieService = await (async () => {
-				const cachedMovieService = getMovieService();
-				if (!listPublicId || cachedMovieService.length > 0) {
-					return cachedMovieService;
-				}
-
-				await hydrateLocalStorageFromDb({ listPublicId });
-				return getMovieService();
-			})();
+			const listItems = await ensureLocalList({ listPublicId });
 
 			const extractedExternalMovieId =
 				extracted.details?.externalDatabaseMovieId;
 
-			const duplicatedMovies = movieService.filter((cachedMovie) => {
+			const duplicatedMovies = listItems.filter((cachedMovie) => {
 				if (
 					extracted.listItemId !== undefined &&
 					cachedMovie.listItemId === extracted.listItemId

--- a/components/Menu/index.tsx
+++ b/components/Menu/index.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useParams, usePathname } from "next/navigation";
+import { useLocalListId } from "@/features/list/hooks/useLocalListId";
 import AddCircleIcon from "../ui/Icons/AddIcon";
 import ListIcon from "../ui/Icons/ListIcon";
 import MenuItem from "./MenuItem";
@@ -10,11 +12,24 @@ type Props = {
 };
 
 export default function Menu({ listPublicId }: Props) {
+	const [localListId, setLocalListId] = useState("");
+
 	const pathname = usePathname();
+
 	const params = useParams<{ publicListId?: string }>();
 
-	const isPublicListPage =
-		typeof params.publicListId === "string" && params.publicListId.length > 0;
+	const { getOrCreateListId } = useLocalListId();
+
+	useEffect(() => {
+		if (
+			typeof params.publicListId === "string" &&
+			params.publicListId.length > 0
+		) {
+			return setLocalListId(params.publicListId);
+		}
+
+		setLocalListId(getOrCreateListId());
+	}, [params.publicListId, getOrCreateListId]);
 
 	return (
 		<nav className="h-(--navigation-height) fixed bottom-(--navigation-bottom) w-full flex justify-center">
@@ -25,8 +40,8 @@ export default function Menu({ listPublicId }: Props) {
 					</a>
 				</MenuItem>
 
-				<MenuItem isCurrentPage={isPublicListPage}>
-					<a href={`/${listPublicId}`}>
+				<MenuItem isCurrentPage={listPublicId !== null}>
+					<a href={listPublicId ? `/${listPublicId}` : `/${localListId}`}>
 						<ListIcon className="size-6" />
 					</a>
 				</MenuItem>

--- a/features/list/hooks/useLocalListId.ts
+++ b/features/list/hooks/useLocalListId.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useCallback } from "react";
+import { useListLocalStorageRepository } from "../repositories/client/useListLocalStorageRepository";
+
+export function useLocalListId() {
+	const { getListId, initializeEmptyList } = useListLocalStorageRepository();
+
+	const getOrCreateListId = useCallback((): string => {
+		const existing = getListId();
+		if (existing) {
+			return existing;
+		}
+
+		initializeEmptyList();
+		return getListId();
+	}, [getListId, initializeEmptyList]);
+
+	return { getOrCreateListId };
+}

--- a/features/list/hooks/useLocalStorage.ts
+++ b/features/list/hooks/useLocalStorage.ts
@@ -6,37 +6,58 @@ import { getUserMovieList } from "../actions/getUserMovieList";
 import { useListLocalStorageRepository } from "../repositories/client/useListLocalStorageRepository";
 
 export function useLocalStorage() {
-	const { appendMovie, replaceMovieService, getMovieService } =
-		useListLocalStorageRepository();
+	const {
+		appendListItem,
+		replaceListItems,
+		getListItems,
+		initializeEmptyList,
+	} = useListLocalStorageRepository();
 	const [storageErrorMessage, setStorageErrorMessage] = useState<string>("");
 
 	const appendMovieToStorage = useCallback(
 		(movie: ListItem) => {
-			appendMovie(movie);
+			appendListItem(movie);
 
 			setStorageErrorMessage("");
 		},
-		[appendMovie],
+		[appendListItem],
 	);
 
-	const hydrateLocalStorageFromDb = useCallback(
-		async ({ listPublicId }: { listPublicId: string }) => {
+	const fetchAndCacheListItems = useCallback(
+		async ({ listPublicId }: { listPublicId: string }): Promise<ListItem[]> => {
 			const result = await getUserMovieList(listPublicId);
 			if (result.success) {
-				replaceMovieService(result.data);
+				replaceListItems(result.data, listPublicId);
 				setStorageErrorMessage("");
-				return;
+				return result.data;
 			}
 
 			setStorageErrorMessage(result.error.message);
+			return getListItems();
 		},
-		[replaceMovieService],
+		[getListItems, replaceListItems],
+	);
+
+	const ensureLocalList = useCallback(
+		async ({ listPublicId }: { listPublicId: string | null }) => {
+			const cachedListItems = getListItems();
+
+			if (!listPublicId || !navigator.onLine) {
+				if (!cachedListItems.length) {
+					initializeEmptyList();
+				}
+				return cachedListItems;
+			}
+
+			return fetchAndCacheListItems({ listPublicId });
+		},
+		[getListItems, fetchAndCacheListItems, initializeEmptyList],
 	);
 
 	return {
 		storageErrorMessage,
 		appendMovieToStorage,
-		hydrateLocalStorageFromDb,
-		getMovieService,
+		ensureLocalList,
+		getListItems,
 	};
 }

--- a/features/list/repositories/client/useListLocalStorageRepository.ts
+++ b/features/list/repositories/client/useListLocalStorageRepository.ts
@@ -1,32 +1,46 @@
 "use client";
 
 import { useSetAtom, useStore } from "jotai";
-import {
-	appendMovieServiceAtom,
-	risutopottoAtom,
-} from "@/features/shared/store";
+import { appendListItemAtom, risutopottoAtom } from "@/features/shared/store";
 import type { ListItem } from "@/features/list/types/ListItem";
 
 export function useListLocalStorageRepository() {
-	const appendMovieService = useSetAtom(appendMovieServiceAtom);
+	const appendListItem = useSetAtom(appendListItemAtom);
 	const setRisutopotto = useSetAtom(risutopottoAtom);
 	const store = useStore();
 
-	const getMovieService = (): ListItem[] => {
-		return store.get(risutopottoAtom).movie_service;
+	const getListItems = (): ListItem[] => {
+		return store.get(risutopottoAtom).list.items;
 	};
 
-	const appendMovie = (movie: ListItem) => {
-		appendMovieService(movie);
+	const getListId = (): string => {
+		return store.get(risutopottoAtom).list.listId;
 	};
 
-	const replaceMovieService = (movieService: ListItem[]) => {
-		setRisutopotto({ movie_service: movieService });
+	const replaceListItems = (listItems: ListItem[], listId?: string) => {
+		const current = store.get(risutopottoAtom);
+		setRisutopotto({
+			list: {
+				listId: listId ?? current.list.listId,
+				items: listItems,
+			},
+		});
+	};
+
+	const initializeEmptyList = () => {
+		setRisutopotto({
+			list: {
+				listId: crypto.randomUUID(),
+				items: [],
+			},
+		});
 	};
 
 	return {
-		getMovieService,
-		appendMovie,
-		replaceMovieService,
+		getListItems,
+		getListId,
+		appendListItem,
+		replaceListItems,
+		initializeEmptyList,
 	};
 }

--- a/features/shared/store/index.ts
+++ b/features/shared/store/index.ts
@@ -5,25 +5,26 @@ import type { ListItem } from "@/features/list/types/ListItem";
 export const LOCAL_STORAGE_KEY = "risutopotto";
 
 export type RisutopottoStorage = {
-	movie_service: ListItem[];
+	list: {
+		listId: string;
+		items: ListItem[];
+	};
 };
 
 export const risutopottoAtom = atomWithStorage<RisutopottoStorage>(
 	LOCAL_STORAGE_KEY,
-	{ movie_service: [] },
+	{ list: { listId: "", items: [] } },
 	undefined,
 	{
 		getOnInit: true,
 	},
 );
 
-export const appendMovieServiceAtom = atom(
+export const appendListItemAtom = atom(
 	null,
 	(get, set, payload: ListItem) => {
 		const current = get(risutopottoAtom);
-		const existing = Array.isArray(current.movie_service)
-			? current.movie_service
-			: [];
+		const existing = current.list.items;
 
 		const next = [
 			...existing,
@@ -35,6 +36,11 @@ export const appendMovieServiceAtom = atom(
 				serviceSlug: payload.serviceSlug,
 			},
 		];
-		set(risutopottoAtom, { movie_service: next });
+		set(risutopottoAtom, {
+			list: {
+				listId: current.list.listId,
+				items: next,
+			},
+		});
 	},
 );


### PR DESCRIPTION
## 変更内容

### LocalStorageの構造を変更
ローカルでリストIDを保持するため。

旧：リストアイテムの配列
新：リストIDとリストアイテムの配列をもつオブジェクト

### LocalStorageへリストを新規作成する処理を追加
未ログイン・未登録でもナビゲーションメニューからリスト画面へリンクさせるため。
DB・ローカルいずれにもリストがなければローカルで新規作成する。