### PR TITLE
リスト取得処理へ自分のリストのみ取得させる認可チェックを追加

### DIFF
--- a/app/[publicListId]/components/List/index.tsx
+++ b/app/[publicListId]/components/List/index.tsx
@@ -1,4 +1,6 @@
+import { isAuthenticated } from "@/features/auth/services/session";
 import { getUserMovieList } from "@/features/list/actions/getUserMovieList";
+import { notFound } from "next/navigation";
 import ListContainer from "./Container";
 import ListItemDetail from "./Item/Detail";
 import ListItem from "./Item";
@@ -9,9 +11,22 @@ type Props = {
 };
 
 export default async function UserMovieList({ publicListId }: Props) {
-	const moviesResult = await getUserMovieList(publicListId);
+	const payload = await isAuthenticated();
+
+	if (!payload) {
+		return <LocalList publicListId={publicListId} />;
+	}
+
+	const moviesResult = await getUserMovieList(publicListId, payload.userId);
 
 	if (!moviesResult.success) {
+		if (
+			moviesResult.error.code === "FORBIDDEN_ERROR" ||
+			moviesResult.error.code === "NOT_FOUND_ERROR"
+		) {
+			notFound();
+		}
+
 		return null;
 	}
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,9 +6,9 @@ import { isAuthenticated } from "@/features/auth/services/session";
 import Section from "@/components/Section";
 
 export default async function Home() {
-	const isVerified = await isAuthenticated();
-	const publicListId = isVerified
-		? await getUserMovieListPublicId(isVerified.userId)
+	const payload = await isAuthenticated();
+	const publicListId = payload
+		? await getUserMovieListPublicId(payload.userId)
 		: null;
 
 	const headersList = await headers();

--- a/features/auth/actions/sendLoginCode.ts
+++ b/features/auth/actions/sendLoginCode.ts
@@ -31,6 +31,7 @@ export async function sendLoginCode(email: string, now: Date): Promise<Result> {
 		return {
 			success: false,
 			error: {
+				code: "VALIDATION_ERROR",
 				message: `送信回数が上限に達しました。${minutesUntilRetry}分後に再度お試しください。`,
 			},
 		};
@@ -41,7 +42,7 @@ export async function sendLoginCode(email: string, now: Date): Promise<Result> {
 	if (!result.success) {
 		return {
 			success: false,
-			error: { message: "メールアドレスが不正です" },
+			error: { code: "VALIDATION_ERROR", message: "メールアドレスが不正です" },
 		};
 	}
 
@@ -49,7 +50,10 @@ export async function sendLoginCode(email: string, now: Date): Promise<Result> {
 		console.error("Resend のAPIキーが設定されていません");
 		return {
 			success: false,
-			error: { message: "メール送信に不具合が見つかりました。" },
+			error: {
+				code: "INTERNAL_ERROR",
+				message: "メール送信に不具合が見つかりました。",
+			},
 		};
 	}
 
@@ -88,7 +92,10 @@ export async function sendLoginCode(email: string, now: Date): Promise<Result> {
 
 			return {
 				success: false,
-				error: { message: "メール送信に不具合があります。" },
+				error: {
+					code: "INTERNAL_ERROR",
+					message: "メール送信に不具合があります。",
+				},
 			};
 		}
 
@@ -107,7 +114,10 @@ export async function sendLoginCode(email: string, now: Date): Promise<Result> {
 		console.error(err);
 		return {
 			success: false,
-			error: { message: "メール送信に不具合があります。" },
+			error: {
+				code: "INTERNAL_ERROR",
+				message: "メール送信に不具合があります。",
+			},
 		};
 	}
 }

--- a/features/auth/actions/verifyLoginCode.ts
+++ b/features/auth/actions/verifyLoginCode.ts
@@ -30,7 +30,10 @@ export async function verifyLoginCode(
 	if (!result.success) {
 		return {
 			success: false,
-			error: { message: "ログインコードが不正です" },
+			error: {
+				code: "VALIDATION_ERROR",
+				message: result.error.message,
+			},
 		};
 	}
 
@@ -53,6 +56,7 @@ export async function verifyLoginCode(
 		return {
 			success: false,
 			error: {
+				code: "VALIDATION_ERROR",
 				message: `試行回数が上限に達しました。${minutesUntilRetry}分後に再度お試しください。`,
 			},
 		};
@@ -89,7 +93,7 @@ export async function verifyLoginCode(
 
 					return {
 						success: false,
-						error: { message: "ログインコードが不正です" },
+						error: { code: "VALIDATION_ERROR", message: "ログインコードが不正です" },
 					};
 				}
 
@@ -180,7 +184,10 @@ export async function verifyLoginCode(
 		console.error(err);
 		return {
 			success: false,
-			error: { message: "ログインの処理に不具合があります。" },
+			error: {
+				code: "INTERNAL_ERROR",
+				message: "内部エラーが発生しました。",
+			},
 		};
 	}
 }

--- a/features/list/actions/getCurrentUserMovieList.ts
+++ b/features/list/actions/getCurrentUserMovieList.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { isAuthenticated } from "@/features/auth/services/session";
+import type { Result } from "@/features/shared/types/Result";
+import type { ListItem } from "@/features/list/types/ListItem";
+import { getUserMovieList as getUserMovieListService } from "../services/listQueryService";
+
+export async function getCurrentUserMovieList(
+	listPublicId: string,
+): Promise<Result<ListItem[]>> {
+	const payload = await isAuthenticated();
+
+	if (!payload) {
+		return {
+			success: false,
+			error: {
+				code: "UNAUTHORIZED_ERROR",
+				message: "",
+			},
+		};
+	}
+
+	return await getUserMovieListService(listPublicId, payload.userId);
+}

--- a/features/list/actions/getUserMovieList.ts
+++ b/features/list/actions/getUserMovieList.ts
@@ -6,6 +6,7 @@ import { getUserMovieList as getUserMovieListService } from "../services/listQue
 
 export async function getUserMovieList(
 	listPublicId: string,
+	userId: number,
 ): Promise<Result<ListItem[]>> {
-	return await getUserMovieListService(listPublicId);
+	return await getUserMovieListService(listPublicId, userId);
 }

--- a/features/list/actions/storeListItem.ts
+++ b/features/list/actions/storeListItem.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import type { Result } from "@/features/shared/types/Result";
-import type { MovieFormError } from "../types/ItemStoreError";
 import type { ListItem } from "../types/ListItem";
 import { storeListItem as storeListItemService } from "../services/listCommandService";
 
@@ -17,7 +16,7 @@ export async function storeListItem({
 	movie,
 	isWatched,
 	now,
-}: Args): Promise<Result<ListItem, MovieFormError>> {
+}: Args): Promise<Result<ListItem>> {
 	return await storeListItemService({
 		publicListId,
 		movie,

--- a/features/list/hooks/useFetchExistingListItem.ts
+++ b/features/list/hooks/useFetchExistingListItem.ts
@@ -1,4 +1,4 @@
-import { getUserMovieList } from "@/features/list/actions/getUserMovieList";
+import { getCurrentUserMovieList } from "@/features/list/actions/getCurrentUserMovieList";
 import { useListLocalStorageRepository } from "../repositories/client/useListLocalStorageRepository";
 
 type Props = {
@@ -10,7 +10,7 @@ export const useFetchExistingListItem = ({ publicListId }: Props) => {
 		useListLocalStorageRepository();
 
 	const fetchCurrentUserList = async (publicListId: string) => {
-		const result = await getUserMovieList(publicListId);
+		const result = await getCurrentUserMovieList(publicListId);
 
 		if (!result.success) {
 			return [];

--- a/features/list/services/listCommandService.ts
+++ b/features/list/services/listCommandService.ts
@@ -1,5 +1,4 @@
 import type { Result } from "@/features/shared/types/Result";
-import type { MovieFormError } from "@/features/list/types/ItemStoreError";
 import type { ListItem } from "@/features/list/types/ListItem";
 import {
 	deleteListItemByPublicId,
@@ -20,22 +19,16 @@ export async function storeListItem({
 	movie: ListItem;
 	isWatched: boolean;
 	now: Date;
-}): Promise<Result<ListItem, MovieFormError>> {
+}): Promise<Result<ListItem>> {
 	const listId = await findListIdByPublicId(publicListId);
 	if (listId === null) {
 		return {
 			success: false,
-			error: { message: "映画リストが見つかりません。" },
+			error: { code: "NOT_FOUND_ERROR", message: "リストが見つかりませんでした。" },
 		};
 	}
 
 	const streamingService = await findStreamingServiceBySlug(movie.serviceSlug);
-	if (!streamingService) {
-		return {
-			success: false,
-			error: { message: "対象の配信サービスが見つかりません。" },
-		};
-	}
 
 	try {
 		const titleOnService = movie.title;
@@ -92,7 +85,10 @@ export async function storeListItem({
 		console.error(error);
 		return {
 			success: false,
-			error: { message: "映画の追加に失敗しました。" },
+			error: {
+				code: "INTERNAL_ERROR",
+				message: "不明なエラーが発生しました。",
+			},
 		};
 	}
 }
@@ -108,7 +104,8 @@ export async function removeListItem({
 			return {
 				success: false,
 				error: {
-					message: "作品がリストへ登録されていないか、すでに削除されています。",
+					code: "NOT_FOUND_ERROR",
+					message: "作品が見つからないか、すでに削除されています。",
 				},
 			};
 		}
@@ -118,7 +115,10 @@ export async function removeListItem({
 		console.error(error);
 		return {
 			success: false,
-			error: { message: "映画の削除に失敗しました。" },
+			error: {
+				code: "INTERNAL_ERROR",
+				message: "不明なエラーが発生しました。",
+			},
 		};
 	}
 }

--- a/features/list/services/listQueryService.ts
+++ b/features/list/services/listQueryService.ts
@@ -8,7 +8,20 @@ import {
 
 export async function getUserMovieList(
 	listPublicId: string,
+	userId: number,
 ): Promise<Result<ListItem[]>> {
+	const currentUserListPublicId = await findListPublicIdByUserId(userId);
+
+	if (currentUserListPublicId !== listPublicId) {
+		return {
+			success: false,
+			error: {
+				code: "FORBIDDEN_ERROR",
+				message: "",
+			},
+		};
+	}
+
 	const rows = await findListItemRowsByListPublicId(listPublicId);
 
 	const movieIds = rows

--- a/features/list/types/ItemStoreError.ts
+++ b/features/list/types/ItemStoreError.ts
@@ -1,3 +1,0 @@
-import type { ZodError } from "zod";
-
-export type MovieFormError = { message: string } | ZodError;

--- a/features/movieDatabase/actions/getDirectorsFromExternalMovieDatabase.ts
+++ b/features/movieDatabase/actions/getDirectorsFromExternalMovieDatabase.ts
@@ -55,6 +55,7 @@ export async function getDirectorsFromExternalMovieDatabase(
 		return {
 			success: false,
 			error: {
+				code: "INTERNAL_ERROR",
 				message: "連携している外部サービスとの接続に不具合があります。",
 			},
 		};
@@ -76,6 +77,7 @@ export async function getDirectorsFromExternalMovieDatabase(
 		return {
 			success: false,
 			error: {
+				code: "INTERNAL_ERROR",
 				message: "連携している外部サービスとの接続に不具合があります。",
 			},
 		};

--- a/features/movieDatabase/actions/getMovieFromExternalMovieDatabase.ts
+++ b/features/movieDatabase/actions/getMovieFromExternalMovieDatabase.ts
@@ -59,6 +59,7 @@ export async function getMovieFromExternalMovieDatabase(
 		return {
 			success: false,
 			error: {
+				code: "INTERNAL_ERROR",
 				message: "連携している外部サービスとの接続に不具合があります。",
 			},
 		};
@@ -80,6 +81,7 @@ export async function getMovieFromExternalMovieDatabase(
 		return {
 			success: false,
 			error: {
+				code: "INTERNAL_ERROR",
 				message: "連携している外部サービスとの接続に不具合があります。",
 			},
 		};

--- a/features/movieDatabase/actions/searchExternalMovieDatabase.ts
+++ b/features/movieDatabase/actions/searchExternalMovieDatabase.ts
@@ -13,6 +13,7 @@ export async function searchExternalMovieDatabase(
 		return {
 			success: false,
 			error: {
+				code: "INTERNAL_ERROR",
 				message: "連携している外部サービスとの接続に不具合があります。",
 			},
 		};
@@ -37,6 +38,7 @@ export async function searchExternalMovieDatabase(
 		return {
 			success: false,
 			error: {
+				code: "INTERNAL_ERROR",
 				message: "連携している外部サービスとの接続に不具合があります。",
 			},
 		};

--- a/features/shared/types/Result.ts
+++ b/features/shared/types/Result.ts
@@ -1,6 +1,13 @@
-export type Result<T = void, E = { message: string }> =
+export type AppError =
+	| { code: "UNAUTHORIZED_ERROR"; message: string }
+	| { code: "FORBIDDEN_ERROR"; message: string }
+	| { code: "NOT_FOUND_ERROR"; message: string }
+	| { code: "VALIDATION_ERROR"; message: string }
+	| { code: "INTERNAL_ERROR"; message: string };
+
+export type Result<T = void> =
 	| (T extends void ? { success: true } : { success: true; data: T })
 	| {
 			success: false;
-			error: E;
+			error: AppError;
 	  };

--- a/features/user/actions/registerUser.ts
+++ b/features/user/actions/registerUser.ts
@@ -61,14 +61,20 @@ export async function registerUser({
 	if (!tempSession) {
 		return {
 			success: false,
-			error: { message: "セッションが無効です。最初からやり直してください。" },
+			error: {
+				code: "UNAUTHORIZED_ERROR",
+				message: "セッションが無効です。最初からやり直してください。",
+			},
 		};
 	}
 
 	if (tempSession.email !== email) {
 		return {
 			success: false,
-			error: { message: "メールアドレスが一致しません。" },
+			error: {
+				code: "UNAUTHORIZED_ERROR",
+				message: "メールアドレスが一致しません。",
+			},
 		};
 	}
 
@@ -77,7 +83,10 @@ export async function registerUser({
 	if (error) {
 		return {
 			success: false,
-			error,
+			error: {
+				code: "VALIDATION_ERROR",
+				message: error.message,
+			},
 		};
 	}
 
@@ -99,6 +108,7 @@ export async function registerUser({
 	});
 
 	let transactionResult: {
+		id: number;
 		publicId: string;
 		listPublicId: string;
 		sessionToken: string;
@@ -208,6 +218,7 @@ export async function registerUser({
 			});
 
 			return {
+				id: newUser.id,
 				publicId: newUser.publicId,
 				listPublicId: newList.publicId,
 				sessionToken,
@@ -226,7 +237,10 @@ export async function registerUser({
 		console.error(err);
 		return {
 			success: false,
-			error: { message: "ユーザー登録の処理に失敗しました。" },
+			error: {
+				code: "INTERNAL_ERROR",
+				message: "ユーザー登録の処理に失敗しました。",
+			},
 		};
 	}
 
@@ -235,6 +249,7 @@ export async function registerUser({
 	try {
 		const listItemsResult = await getUserMovieListService(
 			transactionResult.listPublicId,
+			transactionResult.id,
 		);
 		if (listItemsResult.success) {
 			listItems = listItemsResult.data;


### PR DESCRIPTION
## 変更内容
### Result型に共通のエラーコードを追加

| エラーコード | 内容 |
| --- | --- |
|UNAUTHORIZED_ERROR | 認証 |
|FORBIDDEN_ERROR | 認可 |
|NOT_FOUND_ERROR | 参照 |
|VALIDATION_ERROR | 検証 |
|INTERNAL_ERROR | 不明なエラー |

### リスト取得へ認可チェックを追加

リストのユーザーIDがログイン中ユーザーと一致しなければ認可エラーを返す。