### PR TITLE
リストID取得関数をリファクタリング

### DIFF
--- a/features/list/actions/getUserMovieListPublicId.ts
+++ b/features/list/actions/getUserMovieListPublicId.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { getUserMovieListPublicId as getUserMovieListPublicIdService } from "../services/listQueryService";
+import { getUserMovieListPublicIdService } from "../services/getUserListPublicIdService";
 
 export async function getUserMovieListPublicId(
 	userId: number,

--- a/features/list/repositories/server/listRepository.ts
+++ b/features/list/repositories/server/listRepository.ts
@@ -37,7 +37,7 @@ export async function findListIdByPublicId(listPublicId: string) {
 	return list?.id ?? null;
 }
 
-export async function findListPublicIdByUserId(userId: number) {
+export async function findPublicListIdByUserId(userId: number) {
 	const [list] = await db
 		.select({ publicId: listsTable.publicId })
 		.from(listsTable)

--- a/features/list/services/getUserListPublicIdService.ts
+++ b/features/list/services/getUserListPublicIdService.ts
@@ -1,0 +1,7 @@
+import { findPublicListIdByUserId } from "@/features/list/repositories/server/listRepository";
+
+export async function getUserMovieListPublicIdService(
+	userId: number,
+): Promise<string | null> {
+	return await findPublicListIdByUserId(userId);
+}

--- a/features/list/services/listQueryService.ts
+++ b/features/list/services/listQueryService.ts
@@ -1,7 +1,0 @@
-import { findListPublicIdByUserId } from "@/features/list/repositories/server/listRepository";
-
-export async function getUserMovieListPublicId(
-	userId: number,
-): Promise<string | null> {
-	return await findListPublicIdByUserId(userId);
-}


### PR DESCRIPTION
## 概要

設計方針に基づき、かつてサービス関数だったファイルをリストID取得サービス専用へ変更。

## 変更内容

特定のユースケースに紐づく層と、特定のエンティティに紐づく層は区別が必要。
ユースケース準拠のAction / Serviceは単一ファイル・単一関数とする。

| 層 | 凝集度 | 責務 |
| --- | --- | --- |
| Action | 1ユースケースにつき一つのファイルを作成する。<br>1ファイルあたり一つの関数をエクスポートする。 | 認証チェックとリクエストのバリデーションを行い、Serviceを呼び出す。 |
| Service | 1ユースケースにつき一つのファイルを作成する。<br>1ファイルあたり一つの関数をエクスポートする。 | ビジネスロジックを実装する。複数Repositoryの呼び出し、認可チェック、DTOへの変換を行う。 |
| Repository | 特定のエンティティにつき一つのファイルを作成する。<br>紐付くテーブルを操作する関数をまとめる。 | テーブルに対するCRUD操作を提供する。呼び出し元はDBの詳細を知らなくてよい。 |