### PR TITLE
リストアイテム保存 / 削除の関数をリファクタ・異常系のテストケースを追加

### DIFF
--- a/app/components/ListItem/Drawn/DrawnListItem.stories.tsx
+++ b/app/components/ListItem/Drawn/DrawnListItem.stories.tsx
@@ -9,6 +9,7 @@ const movieWithoutDetails: ListItem = {
 	serviceSlug: "unext",
 	serviceName: "U-NEXT",
 	createdAt: new Date(),
+	isWatched: false
 };
 
 const movieWithDetails: ListItem = {
@@ -18,6 +19,7 @@ const movieWithDetails: ListItem = {
 	serviceSlug: "unext",
 	serviceName: "U-NEXT",
 	createdAt: new Date(),
+	isWatched: false,
 	details: {
 		movieId: 1,
 		officialTitle: "トータル・リコール",

--- a/app/components/ListItem/Editing/EditingListItem.stories.tsx
+++ b/app/components/ListItem/Editing/EditingListItem.stories.tsx
@@ -9,6 +9,7 @@ const movieWithDetails: ListItem = {
 	serviceSlug: "unext",
 	serviceName: "U-NEXT",
 	createdAt: new Date(),
+	isWatched: false,
 	details: {
 		movieId: 1,
 		officialTitle: "トータル・リコール",

--- a/app/components/ListItem/New/NewListItem.stories.tsx
+++ b/app/components/ListItem/New/NewListItem.stories.tsx
@@ -9,6 +9,7 @@ const movieWithoutDetails: ListItem = {
 	serviceSlug: "unext",
 	serviceName: "U-NEXT",
 	createdAt: new Date(),
+	isWatched: false,
 };
 
 const movieWithDetails: ListItem = {
@@ -18,6 +19,7 @@ const movieWithDetails: ListItem = {
 	serviceSlug: "unext",
 	serviceName: "U-NEXT",
 	createdAt: new Date(),
+	isWatched: false,
 	details: {
 		movieId: 1,
 		officialTitle: "トータル・リコール",

--- a/app/components/ListItem/Preview/PreviewListItem.stories.tsx
+++ b/app/components/ListItem/Preview/PreviewListItem.stories.tsx
@@ -9,6 +9,7 @@ const movieWithDetails: ListItem = {
 	serviceSlug: "unext",
 	serviceName: "U-NEXT",
 	createdAt: new Date(),
+	isWatched: false,
 	details: {
 		movieId: 1,
 		officialTitle: "トータル・リコール",

--- a/app/components/ListItem/Watch/WatchListItem.stories.tsx
+++ b/app/components/ListItem/Watch/WatchListItem.stories.tsx
@@ -9,6 +9,7 @@ const movieWithDetails: ListItem = {
 	serviceSlug: "unext",
 	serviceName: "U-NEXT",
 	createdAt: new Date(),
+	isWatched: false,
 	details: {
 		movieId: 1,
 		officialTitle: "トータル・リコール",

--- a/app/components/ListItem/index.tsx
+++ b/app/components/ListItem/index.tsx
@@ -75,6 +75,7 @@ export default function ListItemCard({
 			: {
 					...newItem,
 					listItemId: window.crypto.randomUUID(),
+					isWatched: false
 				};
 
 		storeListItem(itemToStore);

--- a/app/register/components/RegisterForm/index.tsx
+++ b/app/register/components/RegisterForm/index.tsx
@@ -12,10 +12,8 @@ import {
 import { useForm } from "react-hook-form";
 import { useListLocalStorageRepository } from "@/features/list/repositories/client/useListLocalStorageRepository";
 import { userIdSchema } from "@/features/user/schemas/userIdSchema";
-import {
-	registerLocalListItemSchema,
-	registerLocalListPayloadSchema,
-} from "@/features/user/schemas/listItemSchema";
+import { listItemSchema } from "@/features/shared/schemas/listItemSchema";
+import { registerLocalListPayloadSchema } from "@/features/user/schemas/listItemSchema";
 import { searchDuplicateUserId } from "@/features/user/actions/searchDuplicateUserId";
 import { registerUser } from "@/features/user/actions/registerUser";
 import { Input } from "@/components/ui/input";
@@ -92,7 +90,7 @@ export default function RegisterForm({ email, token }: Props) {
 			? {
 					listId: parsedLocalList.data.listId,
 					items: parsedLocalList.data.items.flatMap((item) => {
-						const parsedItem = registerLocalListItemSchema.safeParse(item);
+						const parsedItem = listItemSchema.safeParse(item);
 						if (!parsedItem.success) {
 							return [];
 						}

--- a/features/list/actions/removeListItem.test.ts
+++ b/features/list/actions/removeListItem.test.ts
@@ -23,10 +23,10 @@ describe("removeListItem", () => {
 			})
 			.returning({ id: usersTable.id });
 
-			const [list] = await db
-				.insert(listsTable)
-				.values({ publicId: crypto.randomUUID(), userId: user.id })
-				.returning({ id: listsTable.id });
+		const [list] = await db
+			.insert(listsTable)
+			.values({ publicId: crypto.randomUUID(), userId: user.id })
+			.returning({ id: listsTable.id });
 
 		const [streamingService] = await db
 			.select({ id: streamingServicesTable.id })
@@ -41,8 +41,8 @@ describe("removeListItem", () => {
 		testStreamingServiceId = streamingService.id;
 	});
 
-	it("指定した list_items_table.publicId のレコードを削除できる", async () => {
-		const listItemPublicId = "remove-list-item-target";
+	it("リスト内作品を削除できる", async () => {
+		const listItemPublicId = crypto.randomUUID();
 
 		await db.insert(listItemsTable).values({
 			publicId: listItemPublicId,
@@ -65,14 +65,27 @@ describe("removeListItem", () => {
 		expect(records).toHaveLength(0);
 	});
 
-	it("対象の publicId が存在しない場合はエラーを返す", async () => {
-		const result = await removeListItem({ listItemId: "not-found-public-id" });
+	it("無効な入力値に対してはVALIDATION_ERRORを返す", async () => {
+		const result = await removeListItem({ listItemId: "" });
 
 		expect(result.success).toBe(false);
 		if (result.success) {
 			return;
 		}
 
-		expect(result.error.message).toBe("作品がリストへ登録されていないか、すでに削除されています。");
+		expect(result.error.message).toBe("不正なリクエストです。");
+	});
+
+	it("対象のリスト内作品が存在しない場合はNOT_FOUND_ERRORを返す", async () => {
+		const result = await removeListItem({ listItemId: crypto.randomUUID() });
+
+		expect(result.success).toBe(false);
+		if (result.success) {
+			return;
+		}
+
+		expect(result.error.message).toBe(
+			"作品がリストへ登録されていないか、すでに削除されています。",
+		);
 	});
 });

--- a/features/list/actions/removeListItem.ts
+++ b/features/list/actions/removeListItem.ts
@@ -1,12 +1,30 @@
 "use server";
 
+import z from "zod";
 import type { Result } from "@/features/shared/types/Result";
-import { removeListItem as removeListItemService } from "../services/listCommandService";
+import { removeListItemService } from "../services/removeListItemService";
+
+const removeListItemSchema = z.object({
+	listItemId: z.uuid(),
+});
 
 type Args = {
 	listItemId: string;
 };
 
 export async function removeListItem({ listItemId }: Args): Promise<Result> {
-	return await removeListItemService({ listItemId });
+	const parsed = removeListItemSchema.safeParse({ listItemId });
+
+	if (!parsed.success) {
+		console.error(parsed.error.message);
+		return {
+			success: false,
+			error: {
+				code: "VALIDATION_ERROR",
+				message: "不正なリクエストです。",
+			},
+		};
+	}
+
+	return await removeListItemService({ listItemId: parsed.data.listItemId });
 }

--- a/features/list/actions/storeListItem.test.ts
+++ b/features/list/actions/storeListItem.test.ts
@@ -19,17 +19,14 @@ async function assertStoreMovieResult({
 	publicListId,
 	movie,
 	expectedTitle,
-	isWatched = false,
 }: {
 	publicListId: string;
 	movie: ListItem;
 	expectedTitle: string;
-	isWatched?: boolean;
 }) {
 	const result = await storeListItem({
 		publicListId,
 		movie,
-		isWatched,
 		now: new Date(),
 	});
 
@@ -43,7 +40,7 @@ async function assertStoreMovieResult({
 	expect(result.data.url).toBe(movie.url);
 	expect(result.data.serviceSlug).toBe(movie.serviceSlug);
 	expect(result.data.serviceName).toBe(movie.serviceName);
-	expect(result.data.isWatched).toBe(isWatched);
+	expect(result.data.isWatched).toBe(movie.isWatched);
 	expect(result.data.details).toEqual(movie.details);
 	return result.data;
 }
@@ -218,15 +215,15 @@ describe("storeMovie", () => {
 			})
 			.returning();
 
-			const [list] = await db
-				.insert(listsTable)
-				.values({ publicId: crypto.randomUUID(), userId: user.id })
-				.returning();
+		const [list] = await db
+			.insert(listsTable)
+			.values({ publicId: crypto.randomUUID(), userId: user.id })
+			.returning();
 		testListId = list.id;
 		testListPublicId = list.publicId;
 	});
 
-	it("【TMDBなし】Netflix：ジュラシック・パークをリスト追加", async () => {
+	it("配信作品の情報をリストへ新規登録できる", async () => {
 		const movie: ListItem = {
 			listItemId: crypto.randomUUID(),
 			title: "ジュラシック・パーク",
@@ -234,6 +231,7 @@ describe("storeMovie", () => {
 			serviceSlug: "netflix",
 			serviceName: "Netflix",
 			createdAt: new Date(),
+			isWatched: false,
 		};
 
 		const storeResult = await assertStoreMovieResult({
@@ -261,7 +259,7 @@ describe("storeMovie", () => {
 		}
 	});
 
-	it("【TMDBあり】Prime Video：ジュラシック・パークをリスト追加", async () => {
+	it("配信作品の情報＋マスタの情報を紐づけて新規登録できる", async () => {
 		const tmdbMovieDetails = {
 			backgroundImage: `${TMDB_IMAGE_BASE_URL}/njFixYzIxX8jsn6KMSEtAzi4avi.jpg`,
 			posterImage: `${TMDB_IMAGE_BASE_URL}/qIm2nHXLpBBdMxi8dvfrnDkBUDh.jpg`,
@@ -314,6 +312,7 @@ describe("storeMovie", () => {
 				movieId: seededMovie.id,
 				...tmdbMovieDetails,
 			},
+			isWatched: false,
 		};
 
 		const storeResult = await assertStoreMovieResult({
@@ -346,7 +345,7 @@ describe("storeMovie", () => {
 		});
 	});
 
-	it("同一タイトル・同一URLの作品は登録できない", async () => {
+	it("同じサービスの同じ配信作品は登録できない", async () => {
 		const firstMovie: ListItem = {
 			listItemId: crypto.randomUUID(),
 			title: "ジュラシック・パーク",
@@ -354,6 +353,7 @@ describe("storeMovie", () => {
 			serviceSlug: "netflix",
 			serviceName: "Netflix",
 			createdAt: new Date(),
+			isWatched: false,
 		};
 		const secondMovie: ListItem = {
 			...firstMovie,
@@ -363,7 +363,6 @@ describe("storeMovie", () => {
 		const firstResult = await storeListItem({
 			publicListId: testListPublicId,
 			movie: firstMovie,
-			isWatched: false,
 			now: new Date(),
 		});
 
@@ -372,7 +371,6 @@ describe("storeMovie", () => {
 		const secondResult = await storeListItem({
 			publicListId: testListPublicId,
 			movie: secondMovie,
-			isWatched: false,
 			now: new Date(),
 		});
 
@@ -385,14 +383,84 @@ describe("storeMovie", () => {
 			.select({ id: listItemsTable.id })
 			.from(listItemsTable)
 			.where(
-					and(
-						eq(listItemsTable.listId, testListId),
-						eq(listItemsTable.streamingServiceId, streamingServiceId),
-						eq(listItemsTable.titleOnService, firstMovie.title),
-						eq(listItemsTable.watchUrl, firstMovie.url),
-					),
-				);
+				and(
+					eq(listItemsTable.listId, testListId),
+					eq(listItemsTable.streamingServiceId, streamingServiceId),
+					eq(listItemsTable.titleOnService, firstMovie.title),
+					eq(listItemsTable.watchUrl, firstMovie.url),
+				),
+			);
 
 		expect(storedListItems).toHaveLength(1);
+	});
+
+	it("保存先のリストが存在しない場合はNOT_FOUND_ERRORを返す", async () => {
+		const movie: ListItem = {
+			listItemId: crypto.randomUUID(),
+			title: "ジュラシック・パーク",
+			url: "https://www.netflix.com/jp/title/60002360?s=i&trkid=258593161&vlang=ja&trg=more",
+			serviceSlug: "netflix",
+			serviceName: "Netflix",
+			createdAt: new Date(),
+			isWatched: false,
+		};
+
+		const result = await storeListItem({
+			publicListId: crypto.randomUUID(),
+			movie,
+			now: new Date(),
+		});
+
+		expect(result).toEqual({
+			success: false,
+			error: {
+				code: "NOT_FOUND_ERROR",
+				message: "リストが見つかりませんでした。",
+			},
+		});
+
+		const storedListItems = await db
+			.select({ id: listItemsTable.id })
+			.from(listItemsTable)
+			.where(eq(listItemsTable.listId, testListId));
+
+		expect(storedListItems).toHaveLength(0);
+		await assertMoviesTableHasNoRecords();
+		await assertDirectorsTableHasNoRecords();
+	});
+
+	it("無効な入力値に対してはVALIDATION_ERRORを返す", async () => {
+		const invalidMovie: ListItem = {
+			listItemId: "",
+			title: "",
+			url: "",
+			serviceSlug: "netflix",
+			serviceName: "Netflix",
+			createdAt: new Date(),
+			isWatched: false,
+		};
+
+		const result = await storeListItem({
+			publicListId: testListPublicId,
+			movie: invalidMovie,
+			now: new Date(),
+		});
+
+		expect(result).toEqual({
+			success: false,
+			error: {
+				code: "VALIDATION_ERROR",
+				message: "不正なリクエストです。",
+			},
+		});
+
+		const storedListItems = await db
+			.select({ id: listItemsTable.id })
+			.from(listItemsTable)
+			.where(eq(listItemsTable.listId, testListId));
+
+		expect(storedListItems).toHaveLength(0);
+		await assertMoviesTableHasNoRecords();
+		await assertDirectorsTableHasNoRecords();
 	});
 });

--- a/features/list/actions/storeListItem.ts
+++ b/features/list/actions/storeListItem.ts
@@ -1,26 +1,48 @@
 "use server";
 
+import z from "zod";
 import type { Result } from "@/features/shared/types/Result";
 import type { ListItem } from "../types/ListItem";
-import { storeListItem as storeListItemService } from "../services/listCommandService";
+import { listItemSchema } from "@/features/shared/schemas/listItemSchema";
+import { storeListItemService } from "../services/storeListItemService";
+
+const storeListItemSchema = z.object({
+	publicListId: z.uuid(),
+	movie: listItemSchema,
+	now: z.date(),
+});
 
 type Args = {
 	publicListId: string;
 	movie: ListItem;
-	isWatched: boolean;
 	now: Date;
 };
 
 export async function storeListItem({
 	publicListId,
 	movie,
-	isWatched,
 	now,
 }: Args): Promise<Result<ListItem>> {
+	const parsed = storeListItemSchema.safeParse({
+		publicListId,
+		movie,
+		now,
+	});
+
+	if (!parsed.success) {
+		console.error(parsed.error.message)
+		return {
+			success: false,
+			error: {
+				code: "VALIDATION_ERROR",
+				message: "不正なリクエストです。",
+			},
+		};
+	}
+
 	return await storeListItemService({
 		publicListId,
 		movie,
-		isWatched,
 		now,
 	});
 }

--- a/features/list/hooks/useSubmitMovie.ts
+++ b/features/list/hooks/useSubmitMovie.ts
@@ -28,7 +28,6 @@ export const useSubmitMovie = ({ onSuccess }: { onSuccess?: () => void }) => {
 				publicListId,
 				movie,
 				now: new Date(),
-				isWatched: movie.isWatched ?? false,
 			});
 
 			setSuccess(result.success);

--- a/features/list/services/removeListItemService.ts
+++ b/features/list/services/removeListItemService.ts
@@ -1,0 +1,34 @@
+import type { Result } from "@/features/shared/types/Result";
+import {
+	deleteListItemByPublicId,
+} from "@/features/list/repositories/server/listRepository";
+
+export async function removeListItemService({
+	listItemId,
+}: {
+	listItemId: string;
+}): Promise<Result> {
+	try {
+		const deletedListItemId = await deleteListItemByPublicId(listItemId);
+		if (!deletedListItemId) {
+			return {
+				success: false,
+				error: {
+					code: "NOT_FOUND_ERROR",
+					message: "作品がリストへ登録されていないか、すでに削除されています。",
+				},
+			};
+		}
+
+		return { success: true };
+	} catch (error) {
+		console.error(error);
+		return {
+			success: false,
+			error: {
+				code: "INTERNAL_ERROR",
+				message: "不明なエラーが発生しました。",
+			},
+		};
+	}
+}

--- a/features/list/services/storeListItemService.ts
+++ b/features/list/services/storeListItemService.ts
@@ -1,7 +1,6 @@
 import type { Result } from "@/features/shared/types/Result";
 import type { ListItem } from "@/features/list/types/ListItem";
 import {
-	deleteListItemByPublicId,
 	findListIdByPublicId,
 	findListItemIdByPublicIdAndListId,
 	findStreamingServiceBySlug,
@@ -9,22 +8,23 @@ import {
 	updateListItemByPublicIdAndListId,
 } from "@/features/list/repositories/server/listRepository";
 
-export async function storeListItem({
+export async function storeListItemService({
 	publicListId,
 	movie,
-	isWatched,
 	now,
 }: {
 	publicListId: string;
 	movie: ListItem;
-	isWatched: boolean;
 	now: Date;
 }): Promise<Result<ListItem>> {
 	const listId = await findListIdByPublicId(publicListId);
 	if (listId === null) {
 		return {
 			success: false,
-			error: { code: "NOT_FOUND_ERROR", message: "リストが見つかりませんでした。" },
+			error: {
+				code: "NOT_FOUND_ERROR",
+				message: "リストが見つかりませんでした。",
+			},
 		};
 	}
 
@@ -46,7 +46,7 @@ export async function storeListItem({
 				streamingServiceId: streamingService.id,
 				movieId: movie.details?.movieId ?? null,
 				watchUrl: movie.url,
-				watchStatus: isWatched ? 1 : 0,
+				watchStatus: movie.isWatched ? 1 : 0,
 				titleOnService,
 			});
 		} else {
@@ -56,7 +56,7 @@ export async function storeListItem({
 				streamingServiceId: streamingService.id,
 				movieId: movie.details?.movieId ?? null,
 				watchUrl: movie.url,
-				watchStatus: isWatched ? 1 : 0,
+				watchStatus: movie.isWatched ? 1 : 0,
 				titleOnService,
 				createdAt: now,
 			});
@@ -70,7 +70,7 @@ export async function storeListItem({
 				url: movie.url,
 				serviceSlug: streamingService.slug,
 				serviceName: streamingService.name,
-				isWatched,
+				isWatched: movie.isWatched,
 				createdAt,
 				...(movie.details
 					? {
@@ -81,36 +81,6 @@ export async function storeListItem({
 					: {}),
 			},
 		};
-	} catch (error) {
-		console.error(error);
-		return {
-			success: false,
-			error: {
-				code: "INTERNAL_ERROR",
-				message: "不明なエラーが発生しました。",
-			},
-		};
-	}
-}
-
-export async function removeListItem({
-	listItemId,
-}: {
-	listItemId: string;
-}): Promise<Result> {
-	try {
-		const deletedListItemId = await deleteListItemByPublicId(listItemId);
-		if (!deletedListItemId) {
-			return {
-				success: false,
-				error: {
-					code: "NOT_FOUND_ERROR",
-					message: "作品が見つからないか、すでに削除されています。",
-				},
-			};
-		}
-
-		return { success: true };
 	} catch (error) {
 		console.error(error);
 		return {

--- a/features/list/types/ListItem.ts
+++ b/features/list/types/ListItem.ts
@@ -6,7 +6,7 @@ export type ListItem = {
 	url: string;
 	serviceSlug: SupportedServiceSlug;
 	serviceName: SupportedServiceName;
-	isWatched?: boolean;
+	isWatched: boolean;
 	createdAt: Date;
 	details?: {
 		movieId: number;
@@ -21,4 +21,4 @@ export type ListItem = {
 	};
 };
 
-export type DraftListItem = Omit<ListItem, "listItemId">;
+export type DraftListItem = Omit<ListItem, "listItemId" | "isWatched">;

--- a/features/shared/schemas/listItemSchema.ts
+++ b/features/shared/schemas/listItemSchema.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import { SUPPORTED_SERVICES } from "@/app/consts";
+
+const supportedServiceSlugSchema = z.enum([
+	SUPPORTED_SERVICES.U_NEXT.slug,
+	SUPPORTED_SERVICES.NETFLIX.slug,
+	SUPPORTED_SERVICES.HULU.slug,
+	SUPPORTED_SERVICES.PRIME_VIDEO.slug,
+	SUPPORTED_SERVICES.DISNEY_PLUS.slug,
+]);
+
+const supportedServiceNameSchema = z.enum([
+	SUPPORTED_SERVICES.U_NEXT.name,
+	SUPPORTED_SERVICES.NETFLIX.name,
+	SUPPORTED_SERVICES.HULU.name,
+	SUPPORTED_SERVICES.PRIME_VIDEO.name,
+	SUPPORTED_SERVICES.DISNEY_PLUS.name,
+]);
+
+const listItemDetailsSchema = z.object({
+	movieId: z.number().int().positive(),
+	officialTitle: z.string().min(1),
+	backgroundImage: z.url(),
+	posterImage: z.url(),
+	director: z.array(z.string().min(1)),
+	runningMinutes: z.number().int().positive(),
+	releaseYear: z.number().int(),
+	externalDatabaseMovieId: z.number().int().nonnegative(),
+	overview: z.string().min(1),
+});
+
+export const listItemSchema = z.object({
+	listItemId: z.uuid(),
+	title: z.string().min(1),
+	url: z.url(),
+	serviceSlug: supportedServiceSlugSchema,
+	serviceName: supportedServiceNameSchema,
+	isWatched: z.boolean(),
+	createdAt: z.coerce.date(),
+	details: listItemDetailsSchema.optional(),
+});

--- a/features/shared/store/index.ts
+++ b/features/shared/store/index.ts
@@ -20,28 +20,26 @@ export const risutopottoAtom = atomWithStorage<RisutopottoStorage>(
 	},
 );
 
-export const localListAtom = atom(
-	null,
-	(get, set, payload: ListItem) => {
-		const current = get(risutopottoAtom);
-		const existing = current.list.items;
+export const localListAtom = atom(null, (get, set, payload: ListItem) => {
+	const current = get(risutopottoAtom);
+	const existing = current.list.items;
 
-		const next = [
-			...existing,
-			{
-				listItemId: payload.listItemId,
-				title: payload.title,
-				url: payload.url,
-				createdAt: payload.createdAt,
-				serviceName: payload.serviceName,
-				serviceSlug: payload.serviceSlug,
-			},
-		];
-		set(risutopottoAtom, {
-			list: {
-				listId: current.list.listId,
-				items: next,
-			},
-		});
-	},
-);
+	const next = [
+		...existing,
+		{
+			listItemId: payload.listItemId,
+			title: payload.title,
+			url: payload.url,
+			isWatched: payload.isWatched,
+			createdAt: payload.createdAt,
+			serviceName: payload.serviceName,
+			serviceSlug: payload.serviceSlug,
+		},
+	];
+	set(risutopottoAtom, {
+		list: {
+			listId: current.list.listId,
+			items: next,
+		},
+	});
+});

--- a/features/user/actions/registerUser.ts
+++ b/features/user/actions/registerUser.ts
@@ -14,9 +14,9 @@ import {
 import type { Result } from "@/features/shared/types/Result";
 import type { ListItem } from "@/features/list/types/ListItem";
 import { userIdSchema } from "../schemas/userIdSchema";
+import { listItemSchema } from "@/features/shared/schemas/listItemSchema";
 import {
 	registerLocalListPayloadSchema,
-	registerLocalListItemSchema,
 	type RegisterLocalListInput,
 } from "@/features/user/schemas/listItemSchema";
 import {
@@ -99,7 +99,7 @@ export async function registerUser({
 		? parsedLocalList.data
 		: emptyLocalList;
 	const validLocalListItems = normalizedLocalList.items.flatMap((item) => {
-		const parsedItem = registerLocalListItemSchema.safeParse(item);
+		const parsedItem = listItemSchema.safeParse(item);
 		if (!parsedItem.success) {
 			return [];
 		}

--- a/features/user/schemas/listItemSchema.ts
+++ b/features/user/schemas/listItemSchema.ts
@@ -1,47 +1,7 @@
 import { z } from "zod";
-import { SUPPORTED_SERVICES } from "@/app/consts";
-
-const supportedServiceSlugSchema = z.enum([
-	SUPPORTED_SERVICES.U_NEXT.slug,
-	SUPPORTED_SERVICES.NETFLIX.slug,
-	SUPPORTED_SERVICES.HULU.slug,
-	SUPPORTED_SERVICES.PRIME_VIDEO.slug,
-	SUPPORTED_SERVICES.DISNEY_PLUS.slug,
-]);
-
-const supportedServiceNameSchema = z.enum([
-	SUPPORTED_SERVICES.U_NEXT.name,
-	SUPPORTED_SERVICES.NETFLIX.name,
-	SUPPORTED_SERVICES.HULU.name,
-	SUPPORTED_SERVICES.PRIME_VIDEO.name,
-	SUPPORTED_SERVICES.DISNEY_PLUS.name,
-]);
-
-const localListItemDetailsSchema = z.object({
-	movieId: z.number().int().positive(),
-	officialTitle: z.string().min(1),
-	backgroundImage: z.url(),
-	posterImage: z.url(),
-	director: z.array(z.string().min(1)),
-	runningMinutes: z.number().int().positive(),
-	releaseYear: z.number().int(),
-	externalDatabaseMovieId: z.number().int().nonnegative(),
-	overview: z.string().min(1),
-});
-
-export const registerLocalListItemSchema = z.object({
-	listItemId: z.string().min(1),
-	title: z.string().min(1),
-	url: z.url(),
-	serviceSlug: supportedServiceSlugSchema,
-	serviceName: supportedServiceNameSchema,
-	isWatched: z.boolean().optional(),
-	createdAt: z.coerce.date(),
-	details: localListItemDetailsSchema.optional(),
-});
 
 export const registerLocalListPayloadSchema = z.object({
-	listId: z.string(),
+	listId: z.uuid(),
 	items: z.array(z.unknown()),
 });
 


### PR DESCRIPTION
## 概要

ユースケースごとに単一ファイルへ変更。
Action層へバリデーションを追加。
異常系のテストケースを追加。

## 変更内容

### 視聴ステータスを必須化

もともとはリスト登録時にユーザーが入力できるようにするためオプショナルだった。
しかし現在は視聴ステータスを操作するUIを実装していない。
視聴ステータス更新の優先度はあまり高くないため、初期値を`false`（未視聴）として必須化する。

### リストアイテムのバリデーション用スキーマを共通化

ユーザーの新規登録時、localStorageの値をDBへ格納する際にバリデーションを行うようにしていた。
リストアイテム保存の処理でも同様のバリデーションを行うため、スキーマを`shared`へ移植。

### テストコードの修正

仕様を直接表現するテストケース名へ変更。
異常系を最低限カバーするテストケースを追加。