### PR TITLE
Layoutと各ページの認証チェックを最適化

### DIFF
--- a/app/[publicListId]/components/List/index.tsx
+++ b/app/[publicListId]/components/List/index.tsx
@@ -1,4 +1,4 @@
-import { isAuthenticated } from "@/features/auth/services/session";
+import { currentUserId } from "@/features/shared/actions/currentUserId";
 import { getUserMovieList } from "@/features/list/actions/getUserMovieList";
 import { notFound } from "next/navigation";
 import ListContainer from "./Container";
@@ -11,13 +11,13 @@ type Props = {
 };
 
 export default async function UserMovieList({ publicListId }: Props) {
-	const payload = await isAuthenticated();
+	const result = await currentUserId();
 
-	if (!payload) {
+	if (!result.success) {
 		return <LocalList publicListId={publicListId} />;
 	}
 
-	const moviesResult = await getUserMovieList(publicListId, payload.userId);
+	const moviesResult = await getUserMovieList(publicListId, result.data.userId);
 
 	if (!moviesResult.success) {
 		if (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
-import { getUserMovieListPublicId } from "@/features/list/actions/getUserMovieListPublicId";
-import { isAuthenticated } from "@/features/auth/services/session";
+import { currentUserPublicListId } from "@/features/shared/actions/currentUserPublicListId";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import Menu from "@/components/Menu";
@@ -16,19 +15,19 @@ export default async function RootLayout({
 }: Readonly<{
 	children: React.ReactNode;
 }>) {
-	const isVerified = await isAuthenticated();
-	const listPublicId = isVerified
-		? await getUserMovieListPublicId(isVerified.userId)
-		: null;
+	const result = await currentUserPublicListId();
+	const publicListId = result.success ? result.data.publicListId : null;
 
 	return (
 		<html lang="ja">
 			<body className={`antialiased`}>
 				<Header />
 
-				<main className="min-h-[calc(100dvh-var(--header-height))] pb-20">{children}</main>
+				<main className="min-h-[calc(100dvh-var(--header-height))] pb-20">
+					{children}
+				</main>
 
-				<Menu listPublicId={listPublicId} />
+				<Menu listPublicId={publicListId} />
 
 				<Footer />
 			</body>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,11 +1,11 @@
 import { redirect } from "next/navigation";
-import { isAuthenticated } from "@/features/auth/services/session";
+import { currentUserId } from "@/features/shared/actions/currentUserId";
 import Login from "./components/Login";
 
 export default async function LoginPage() {
-	const authenticated = await isAuthenticated();
+	const result = await currentUserId();
 
-	if (authenticated) {
+	if (result.success) {
 		redirect("/");
 	}
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,12 @@
 import { headers } from "next/headers";
-import { getUserMovieListPublicId } from "@/features/list/actions/getUserMovieListPublicId";
+import { currentUserPublicListId } from "@/features/shared/actions/currentUserPublicListId";
 import MovieInputForm from "./components/MovieInputForm";
 import Roulette from "./components/Roulette";
-import { isAuthenticated } from "@/features/auth/services/session";
 import Section from "@/components/Section";
 
 export default async function Home() {
-	const payload = await isAuthenticated();
-	const publicListId = payload
-		? await getUserMovieListPublicId(payload.userId)
-		: null;
+	const result = await currentUserPublicListId();
+	const publicListId = result.success ? result.data.publicListId : null;
 
 	const headersList = await headers();
 	const userAgent = headersList.get("user-agent") || "";

--- a/features/auth/services/loginService.ts
+++ b/features/auth/services/loginService.ts
@@ -2,6 +2,7 @@ import { SignJWT } from "jose";
 import crypto from "node:crypto";
 import { db } from "@/db/client";
 import type { Tx } from "@/db/client";
+import { getSecretKey } from "@/lib/jwt";
 import type { Result } from "@/features/shared/types/Result";
 import { insertAttempt } from "../repositories/attemptRepository";
 import {
@@ -138,14 +139,6 @@ export async function loginService({
 
 function generateTempSessionToken() {
 	return crypto.randomBytes(32).toString("hex");
-}
-
-function getSecretKey(): Uint8Array {
-	const secret = process.env.JWT_SECRET;
-	if (!secret) {
-		throw new Error("JWT_SECRET is not defined");
-	}
-	return new TextEncoder().encode(secret);
 }
 
 async function generateSessionToken({

--- a/features/auth/services/session.test.ts
+++ b/features/auth/services/session.test.ts
@@ -2,12 +2,9 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { db } from "@/db/client";
 import { authTokensTable, usersTable } from "@/db/schema";
 import {
-	generateSessionToken,
 	generateTempSessionToken,
-	verifySessionToken,
 	verifyTempSessionToken,
 } from "./session";
-import { eq } from "drizzle-orm";
 
 describe("auth token verification", () => {
 	const now = new Date("2026-02-16T00:00:00.000Z");
@@ -15,50 +12,6 @@ describe("auth token verification", () => {
 	beforeEach(async () => {
 		await db.delete(authTokensTable);
 		await db.delete(usersTable);
-	});
-
-	it("有効な認証トークンを検証できる", async () => {
-		const email = "verify-session-token-test@example.com";
-		const deviceId = "test-device-id";
-
-		await db.insert(usersTable).values({
-			publicId: "verify-session-token-test-user",
-			email,
-		});
-
-		const [user] = await db
-			.select({ id: usersTable.id })
-			.from(usersTable)
-			.where(eq(usersTable.email, email));
-
-		expect(user).toBeDefined();
-		if (!user) {
-			return;
-		}
-
-		const sessionToken = await generateSessionToken({
-			userId: user.id,
-			email,
-			deviceId,
-		});
-
-		await db.insert(authTokensTable).values({
-			token: sessionToken,
-			tokenType: "session_token",
-			email,
-			userId: user.id,
-			deviceId,
-			expiresAt: new Date(now.getTime() + 10 * 60 * 1000),
-			createdAt: now,
-		});
-
-		const result = await verifySessionToken({ sessionToken, now });
-
-		expect(result).toStrictEqual({
-			userId: user.id,
-			email,
-			deviceId,
-		});
 	});
 
 	it("有効な仮認証トークンを検証できる", async () => {

--- a/features/auth/services/session.ts
+++ b/features/auth/services/session.ts
@@ -1,85 +1,8 @@
-import { jwtVerify, SignJWT } from "jose";
+import { SignJWT } from "jose";
 import crypto from "node:crypto";
 import { db } from "@/db/client";
 import { authTokensTable } from "@/db/schema";
 import { and, eq, gt } from "drizzle-orm";
-import { cookies } from "next/headers";
-
-export async function verifySessionToken({
-	sessionToken,
-	now,
-}: {
-	sessionToken?: string;
-	now: Date;
-}): Promise<{
-	userId: number;
-	email: string;
-	deviceId: string;
-} | null> {
-	if (!sessionToken) {
-		return null;
-	}
-
-	try {
-		const secretKey = getSecretKey();
-		const { payload } = await jwtVerify(sessionToken, secretKey, {
-			algorithms: ["HS256"],
-		});
-
-		if (payload.type !== "session_token") {
-			return null;
-		}
-
-		const { userId, email, deviceId, type, exp, iat } = payload;
-
-		if (
-			typeof userId === "string" &&
-			typeof email === "string" &&
-			typeof deviceId === "string" &&
-			typeof type === "string" &&
-			typeof exp === "number" &&
-			typeof iat === "number"
-		) {
-			const parsedUserId = Number(userId);
-			if (!Number.isFinite(parsedUserId)) {
-				return null;
-			}
-
-			const [record] = await db
-				.select({
-					userId: authTokensTable.userId,
-					email: authTokensTable.email,
-					deviceId: authTokensTable.deviceId,
-				})
-				.from(authTokensTable)
-				.where(
-					and(
-						eq(authTokensTable.token, sessionToken),
-						eq(authTokensTable.tokenType, "session_token"),
-						eq(authTokensTable.userId, parsedUserId),
-						eq(authTokensTable.email, email),
-						eq(authTokensTable.deviceId, deviceId),
-						gt(authTokensTable.expiresAt, now),
-					),
-				);
-
-			if (!record) {
-				return null;
-			}
-
-			return {
-				userId: parsedUserId,
-				email: record.email,
-				deviceId: record.deviceId ?? deviceId,
-			};
-		}
-
-		return null;
-	} catch (error) {
-		console.error("Token verification failed:", error);
-		return null;
-	}
-}
 
 export async function verifyTempSessionToken({
 	tempToken,
@@ -117,18 +40,6 @@ export async function verifyTempSessionToken({
 		console.error("Temp token verification failed:", error);
 		return null;
 	}
-}
-
-export async function isAuthenticated() {
-	const cookieStore = await cookies();
-	const sessionToken = cookieStore.get("session_token")?.value;
-
-	const payload = await verifySessionToken({
-		sessionToken,
-		now: new Date(),
-	});
-
-	return payload;
 }
 
 function getSecretKey(): Uint8Array {

--- a/features/auth/services/verifySessionTokenService.ts
+++ b/features/auth/services/verifySessionTokenService.ts
@@ -1,0 +1,111 @@
+import type { Result } from "@/features/shared/types/Result";
+import { jwtVerify } from "jose";
+import { db } from "@/db/client";
+import { authTokensTable } from "@/db/schema";
+import { and, eq, gt } from "drizzle-orm";
+import { getSecretKey } from "@/lib/jwt";
+
+export async function verifySessionTokenService({
+	sessionToken,
+	now,
+}: {
+	sessionToken: string;
+	now: Date;
+}): Promise<Result<{ userId: number }>> {
+	const secretKey = getSecretKey();
+
+	try {
+		const { payload } = await jwtVerify(sessionToken, secretKey, {
+			algorithms: ["HS256"],
+		});
+
+		if (payload.type !== "session_token") {
+			return {
+				success: false,
+				error: {
+					code: "UNAUTHORIZED_ERROR",
+					message: "",
+				},
+			};
+		}
+
+		const { userId, email, deviceId, type } = payload;
+
+		const isString = (propName: unknown): propName is string => {
+			return typeof propName === "string";
+		};
+
+		if (!isString(userId) || !isString(email) || !isString(deviceId)) {
+			console.error("セッションの検証中に内部エラーが発生しました。");
+			console.error(JSON.stringify(payload));
+
+			return {
+				success: false,
+				error: {
+					code: "INTERNAL_ERROR",
+					message: "",
+				},
+			};
+		}
+
+		const parsedUserId = Number(userId);
+
+		if (Number.isFinite(parsedUserId) === false) {
+			console.error("セッションの検証中に内部エラーが発生しました。");
+			console.error(`userId: ${userId}`);
+			console.error(`parsedUserId: ${parsedUserId}`);
+
+			return {
+				success: false,
+				error: {
+					code: "INTERNAL_ERROR",
+					message: "",
+				},
+			};
+		}
+
+		const [record] = await db
+			.select({
+				userId: authTokensTable.userId,
+				email: authTokensTable.email,
+				deviceId: authTokensTable.deviceId,
+			})
+			.from(authTokensTable)
+			.where(
+				and(
+					eq(authTokensTable.token, sessionToken),
+					eq(authTokensTable.tokenType, type),
+					eq(authTokensTable.userId, parsedUserId),
+					eq(authTokensTable.email, email),
+					eq(authTokensTable.deviceId, deviceId),
+					gt(authTokensTable.expiresAt, now),
+				),
+			);
+
+		if (!record) {
+			return {
+				success: false,
+				error: {
+					code: "UNAUTHORIZED_ERROR",
+					message: "",
+				},
+			};
+		}
+
+		return {
+			success: true,
+			data: {
+				userId: parsedUserId,
+			},
+		};
+	} catch (error) {
+		console.error("Token verification failed:", error);
+		return {
+			success: false,
+			error: {
+				code: "INTERNAL_ERROR",
+				message: "不明なエラーが発生しました。",
+			},
+		};
+	}
+}

--- a/features/list/actions/getCurrentUserMovieList.test.ts
+++ b/features/list/actions/getCurrentUserMovieList.test.ts
@@ -1,23 +1,44 @@
 import crypto from "node:crypto";
+import { SignJWT } from "jose";
 import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "@/db/client";
 import {
+	authTokensTable,
 	listItemsTable,
 	listsTable,
 	streamingServicesTable,
 	usersTable,
 } from "@/db/schema";
+import { getSecretKey } from "@/lib/jwt";
 import { getCurrentUserMovieList } from "./getCurrentUserMovieList";
 
-const { mockIsAuthenticated } = vi.hoisted(() => {
+const { mockCookies, mockSessionTokenStore } = vi.hoisted(() => {
+	let sessionToken: string | undefined;
+
 	return {
-		mockIsAuthenticated: vi.fn(),
+		mockCookies: vi.fn(async () => ({
+			get: (name: string) => {
+				if (name !== "session_token" || !sessionToken) {
+					return undefined;
+				}
+
+				return { value: sessionToken };
+			},
+		})),
+		mockSessionTokenStore: {
+			clear() {
+				sessionToken = undefined;
+			},
+			set(value: string) {
+				sessionToken = value;
+			},
+		},
 	};
 });
 
-vi.mock("@/features/auth/services/session", () => ({
-	isAuthenticated: mockIsAuthenticated,
+vi.mock("next/headers", () => ({
+	cookies: mockCookies,
 }));
 
 async function findStreamingServiceIdBySlug(slug: "netflix" | "hulu") {
@@ -35,15 +56,67 @@ async function findStreamingServiceIdBySlug(slug: "netflix" | "hulu") {
 	return streamingService.id;
 }
 
+async function generateSessionToken({
+	userId,
+	email,
+	deviceId,
+}: {
+	userId: number;
+	email: string;
+	deviceId: string;
+}) {
+	return await new SignJWT({
+		userId: userId.toString(),
+		email,
+		deviceId,
+		type: "session_token",
+	})
+		.setProtectedHeader({ alg: "HS256" })
+		.setExpirationTime("30d")
+		.setIssuedAt()
+		.sign(getSecretKey());
+}
+
+async function loginAsUser({
+	userId,
+	email,
+	now,
+}: {
+	userId: number;
+	email: string;
+	now: Date;
+}) {
+	const sessionToken = await generateSessionToken({
+		userId,
+		email,
+		deviceId: "test-device-id",
+	});
+
+	await db.insert(authTokensTable).values({
+		token: sessionToken,
+		tokenType: "session_token",
+		email,
+		userId,
+		deviceId: "test-device-id",
+		expiresAt: new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000),
+		createdAt: now,
+	});
+
+	mockSessionTokenStore.set(sessionToken);
+}
+
 describe("getCurrentUserMovieList", () => {
 	let userAId = 0;
 	let userBId = 0;
 	let userAListPublicId = "";
 	let userBListPublicId = "";
+	const now = new Date("2026-03-12T00:00:00.000Z");
 
 	beforeEach(async () => {
-		mockIsAuthenticated.mockReset();
+		mockCookies.mockClear();
+		mockSessionTokenStore.clear();
 
+		await db.delete(authTokensTable);
 		await db.delete(listItemsTable);
 		await db.delete(listsTable);
 		await db.delete(usersTable);
@@ -123,16 +196,16 @@ describe("getCurrentUserMovieList", () => {
 		]);
 	});
 
-	it("ユーザーは自身のリストアイテム全件を取得できる", async () => {
-		mockIsAuthenticated.mockResolvedValue({
+	it("ログイン中ユーザーは自身のリストアイテム全件を取得できる", async () => {
+		await loginAsUser({
 			userId: userAId,
 			email: "get-current-user-movie-list-user-a@example.com",
-			deviceId: "test-device-id",
+			now,
 		});
 
 		const result = await getCurrentUserMovieList(userAListPublicId);
 
-		expect(mockIsAuthenticated).toHaveBeenCalledTimes(1);
+		expect(mockCookies).toHaveBeenCalledTimes(1);
 		expect(result).toEqual({
 			success: true,
 			data: [
@@ -159,10 +232,10 @@ describe("getCurrentUserMovieList", () => {
 	});
 
 	it("ユーザーは他ユーザーのリストアイテムを取得できない", async () => {
-		mockIsAuthenticated.mockResolvedValue({
+		await loginAsUser({
 			userId: userAId,
 			email: "get-current-user-movie-list-user-a@example.com",
-			deviceId: "test-device-id",
+			now,
 		});
 
 		const result = await getCurrentUserMovieList(userBListPublicId);
@@ -177,11 +250,9 @@ describe("getCurrentUserMovieList", () => {
 	});
 
 	it("ユーザーはログイン中でなければリストアイテムを取得できない", async () => {
-		mockIsAuthenticated.mockResolvedValue(null);
-
 		const result = await getCurrentUserMovieList(userAListPublicId);
 
-		expect(mockIsAuthenticated).toHaveBeenCalledTimes(1);
+		expect(mockCookies).toHaveBeenCalledTimes(1);
 		expect(result).toEqual({
 			success: false,
 			error: {
@@ -192,10 +263,10 @@ describe("getCurrentUserMovieList", () => {
 	});
 
 	it("ユーザーは存在しないリストからリストアイテムを取得できない", async () => {
-		mockIsAuthenticated.mockResolvedValue({
+		await loginAsUser({
 			userId: userAId,
 			email: "get-current-user-movie-list-user-a@example.com",
-			deviceId: "test-device-id",
+			now,
 		});
 
 		const result = await getCurrentUserMovieList(crypto.randomUUID());

--- a/features/list/actions/getCurrentUserMovieList.ts
+++ b/features/list/actions/getCurrentUserMovieList.ts
@@ -1,10 +1,10 @@
 "use server";
 
 import z from "zod";
-import { isAuthenticated } from "@/features/auth/services/session";
 import type { Result } from "@/features/shared/types/Result";
 import type { ListItem } from "@/features/list/types/ListItem";
 import { getUserListService } from "../services/getUserListService";
+import { currentUserId } from "@/features/shared/actions/currentUserId";
 
 const getCurrentUserMovieListSchema = z.object({
 	listPublicId: z.uuid(),
@@ -25,9 +25,9 @@ export async function getCurrentUserMovieList(
 		};
 	}
 
-	const payload = await isAuthenticated();
+	const result = await currentUserId();
 
-	if (!payload) {
+	if (!result.success) {
 		return {
 			success: false,
 			error: {
@@ -37,5 +37,5 @@ export async function getCurrentUserMovieList(
 		};
 	}
 
-	return await getUserListService(listPublicId, payload.userId);
+	return await getUserListService(listPublicId, result.data.userId);
 }

--- a/features/list/actions/getUserMovieListPublicId.ts
+++ b/features/list/actions/getUserMovieListPublicId.ts
@@ -1,9 +1,27 @@
 "use server";
 
+import type { Result } from "@/features/shared/types/Result";
 import { getUserMovieListPublicIdService } from "../services/getUserListPublicIdService";
 
 export async function getUserMovieListPublicId(
 	userId: number,
-): Promise<string | null> {
-	return await getUserMovieListPublicIdService(userId);
+): Promise<Result<{ publicListId: string }>> {
+	const publicListId = await getUserMovieListPublicIdService(userId);
+
+	if (!publicListId) {
+		return {
+			success: false,
+			error: {
+				code: "NOT_FOUND_ERROR",
+				message: "リストが見つかりませんでした。",
+			},
+		};
+	}
+
+	return {
+		success: true,
+		data: {
+			publicListId,
+		},
+	};
 }

--- a/features/shared/actions/currentUserId.ts
+++ b/features/shared/actions/currentUserId.ts
@@ -1,0 +1,28 @@
+"use server";
+
+import type { Result } from "../types/Result";
+import { cache } from "react";
+import { cookies } from "next/headers";
+import { verifySessionTokenService } from "@/features/auth/services/verifySessionTokenService";
+
+export const currentUserId = cache(
+	async (): Promise<Result<{ userId: number }>> => {
+		const cookieStore = await cookies();
+		const sessionToken = cookieStore.get("session_token")?.value;
+
+		if (!sessionToken) {
+			return {
+				success: false,
+				error: {
+					code: "UNAUTHORIZED_ERROR",
+					message: "ログインしていません。"
+				}
+			};
+		}
+
+		return await verifySessionTokenService({
+			sessionToken,
+			now: new Date(),
+		});
+	},
+);

--- a/features/shared/actions/currentUserPublicListId.ts
+++ b/features/shared/actions/currentUserPublicListId.ts
@@ -1,0 +1,18 @@
+"use server";
+
+import { cache } from "react";
+import type { Result } from "../types/Result";
+import { currentUserId } from "./currentUserId";
+import { getUserMovieListPublicId } from "@/features/list/actions/getUserMovieListPublicId";
+
+export const currentUserPublicListId = cache(
+	async (): Promise<Result<{ publicListId: string }>> => {
+		const result = await currentUserId();
+
+		if (!result.success) {
+			return result;
+		}
+
+		return await getUserMovieListPublicId(result.data.userId);
+	},
+);

--- a/lib/jwt.ts
+++ b/lib/jwt.ts
@@ -1,0 +1,7 @@
+export function getSecretKey(): Uint8Array {
+	const secret = process.env.JWT_SECRET;
+	if (!secret) {
+		throw new Error("JWT_SECRET is not defined");
+	}
+	return new TextEncoder().encode(secret);
+}


### PR DESCRIPTION
## 概要
認証チェック / ログイン中ユーザーのリストIDが二重に実行されていた。
Reactの`cache`でこれをキャッシュし、同一リクエスト内での二重実行を防ぐように修正。

## 変更内容

認証チェック / リストID取得をそれぞれResultを返すサーバーアクションへ統一。
Cookieの認証トークンを検証するロジックをサービス層へ移植。
検証処理の旧実装と単体のテストコードを削除。