### PR TITLE
ユーザーのテーブルからメールアドレスカラムを分離する別テーブルを追加

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -4,6 +4,15 @@ import type { SupportedServiceName, SupportedServiceSlug } from "@/app/consts";
 export const usersTable = sqliteTable("users_table", {
 	id: int().primaryKey({ autoIncrement: true }),
 	publicId: text().notNull().unique(),
+});
+
+export const userEmailsTable = sqliteTable("user_emails_table", {
+	id: int().primaryKey({ autoIncrement: true }),
+	userId: int("user_id")
+		.notNull()
+		.references(() => usersTable.id, {
+			onDelete: "cascade",
+		}),
 	email: text("email").notNull().unique(),
 });
 

--- a/features/auth/actions/login.test.ts
+++ b/features/auth/actions/login.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "@/db/client";
 import type { Tx } from "@/db/client";
-import { authTokensTable, loginAttemptsTable, usersTable } from "@/db/schema";
+import {
+	authTokensTable,
+	loginAttemptsTable,
+	userEmailsTable,
+	usersTable,
+} from "@/db/schema";
 import { login } from "./login";
 import { createHash, randomInt } from "node:crypto";
 import { and, eq } from "drizzle-orm";
@@ -57,9 +62,10 @@ async function insertLoginCode({
 	createdAt: Date;
 }) {
 	const [user] = await tx
-		.select()
+		.select({ id: usersTable.id })
 		.from(usersTable)
-		.where(eq(usersTable.email, email));
+		.innerJoin(userEmailsTable, eq(userEmailsTable.userId, usersTable.id))
+		.where(eq(userEmailsTable.email, email));
 
 	await tx.insert(authTokensTable).values({
 		token,
@@ -84,8 +90,11 @@ describe("login", () => {
 		mockCookies.mockClear();
 		mockHeaders.mockClear();
 		mockSetCookie.mockReset();
-		await db.insert(usersTable).values({
+		const [user] = await db.insert(usersTable).values({
 			publicId: "verify-login-code-test-user",
+		}).returning({ id: usersTable.id });
+		await db.insert(userEmailsTable).values({
+			userId: user.id,
 			email,
 		});
 

--- a/features/auth/actions/sendLoginCode.test.ts
+++ b/features/auth/actions/sendLoginCode.test.ts
@@ -2,7 +2,12 @@ import { createHash } from "node:crypto";
 import { and, eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "@/db/client";
-import { authTokensTable, loginAttemptsTable, usersTable } from "@/db/schema";
+import {
+	authTokensTable,
+	loginAttemptsTable,
+	userEmailsTable,
+	usersTable,
+} from "@/db/schema";
 
 const originalResendApiKey = process.env.RESEND_API_KEY;
 const originalVercelUrl = process.env.VERCEL_URL;
@@ -78,13 +83,17 @@ describe("sendLoginCode", () => {
 			.insert(usersTable)
 			.values({
 				publicId: "send-login-code-test-user",
-				email: existingUserEmail,
 			})
 			.returning();
 
 		if (!user) {
 			throw new Error("既存ユーザーのシードに失敗しました");
 		}
+
+		await db.insert(userEmailsTable).values({
+			userId: user.id,
+			email: existingUserEmail,
+		});
 
 		return user;
 	}
@@ -100,6 +109,7 @@ describe("sendLoginCode", () => {
 
 		await db.delete(loginAttemptsTable);
 		await db.delete(authTokensTable);
+		await db.delete(userEmailsTable);
 		await db.delete(usersTable);
 	});
 

--- a/features/list/actions/getCurrentUserMovieList.test.ts
+++ b/features/list/actions/getCurrentUserMovieList.test.ts
@@ -8,6 +8,7 @@ import {
 	listItemsTable,
 	listsTable,
 	streamingServicesTable,
+	userEmailsTable,
 	usersTable,
 } from "@/db/schema";
 import { getSecretKey } from "@/lib/jwt";
@@ -125,17 +126,23 @@ describe("getCurrentUserMovieList", () => {
 			.insert(usersTable)
 			.values({
 				publicId: "get-current-user-movie-list-user-a",
-				email: "get-current-user-movie-list-user-a@example.com",
 			})
 			.returning({ id: usersTable.id });
+		await db.insert(userEmailsTable).values({
+			userId: userA.id,
+			email: "get-current-user-movie-list-user-a@example.com",
+		});
 
 		const [userB] = await db
 			.insert(usersTable)
 			.values({
 				publicId: "get-current-user-movie-list-user-b",
-				email: "get-current-user-movie-list-user-b@example.com",
 			})
 			.returning({ id: usersTable.id });
+		await db.insert(userEmailsTable).values({
+			userId: userB.id,
+			email: "get-current-user-movie-list-user-b@example.com",
+		});
 
 		userAId = userA.id;
 		userBId = userB.id;

--- a/features/list/actions/getUserMovieList.test.ts
+++ b/features/list/actions/getUserMovieList.test.ts
@@ -6,6 +6,7 @@ import {
 	listItemsTable,
 	listsTable,
 	streamingServicesTable,
+	userEmailsTable,
 	usersTable,
 } from "@/db/schema";
 import { getUserMovieList } from "./getUserMovieList";
@@ -40,17 +41,23 @@ describe("getUserMovieList", () => {
 			.insert(usersTable)
 			.values({
 				publicId: "get-user-movie-list-user-a",
-				email: "get-user-movie-list-user-a@example.com",
 			})
 			.returning({ id: usersTable.id });
+		await db.insert(userEmailsTable).values({
+			userId: userA.id,
+			email: "get-user-movie-list-user-a@example.com",
+		});
 
 		const [userB] = await db
 			.insert(usersTable)
 			.values({
 				publicId: "get-user-movie-list-user-b",
-				email: "get-user-movie-list-user-b@example.com",
 			})
 			.returning({ id: usersTable.id });
+		await db.insert(userEmailsTable).values({
+			userId: userB.id,
+			email: "get-user-movie-list-user-b@example.com",
+		});
 
 		userAId = userA.id;
 		userBId = userB.id;

--- a/features/list/actions/removeListItem.test.ts
+++ b/features/list/actions/removeListItem.test.ts
@@ -6,6 +6,7 @@ import {
 	listItemsTable,
 	listsTable,
 	streamingServicesTable,
+	userEmailsTable,
 	usersTable,
 } from "@/db/schema";
 import { removeListItem } from "./removeListItem";
@@ -19,9 +20,12 @@ describe("removeListItem", () => {
 			.insert(usersTable)
 			.values({
 				publicId: "remove-list-item-test-user",
-				email: "remove-list-item-test@risutopo.com",
 			})
 			.returning({ id: usersTable.id });
+		await db.insert(userEmailsTable).values({
+			userId: user.id,
+			email: "remove-list-item-test@risutopo.com",
+		});
 
 		const [list] = await db
 			.insert(listsTable)

--- a/features/list/actions/storeListItem.test.ts
+++ b/features/list/actions/storeListItem.test.ts
@@ -9,6 +9,7 @@ import {
 	movieDirectorsTable,
 	moviesTable,
 	streamingServicesTable,
+	userEmailsTable,
 	usersTable,
 } from "@/db/schema";
 import type { ListItem } from "../types/ListItem";
@@ -211,9 +212,12 @@ describe("storeMovie", () => {
 			.insert(usersTable)
 			.values({
 				publicId: "test",
-				email: "xxxxxxx@risutopo.com",
 			})
 			.returning();
+		await db.insert(userEmailsTable).values({
+			userId: user.id,
+			email: "xxxxxxx@risutopo.com",
+		});
 
 		const [list] = await db
 			.insert(listsTable)

--- a/features/user/actions/registerUser.ts
+++ b/features/user/actions/registerUser.ts
@@ -6,6 +6,7 @@ import { db } from "@/db/client";
 import { and, eq, inArray } from "drizzle-orm";
 import {
 	usersTable,
+	userEmailsTable,
 	listsTable,
 	authTokensTable,
 	listItemsTable,
@@ -113,9 +114,16 @@ export async function registerUser({
 				.insert(usersTable)
 				.values({
 					publicId: data.userId,
-					email: email,
 				})
-				.returning();
+				.returning({
+					id: usersTable.id,
+					publicId: usersTable.publicId,
+				});
+
+			await tx.insert(userEmailsTable).values({
+				userId: newUser.id,
+				email,
+			});
 
 			const normalizedListPublicId =
 				normalizedLocalList.listId.length > 0
@@ -194,7 +202,7 @@ export async function registerUser({
 
 			const sessionToken = await generateSessionToken({
 				userId: newUser.id,
-				email: newUser.email,
+				email,
 				deviceId,
 			});
 			const expiresAt = addDays(now, 30);

--- a/features/user/repositories/userRepository.ts
+++ b/features/user/repositories/userRepository.ts
@@ -1,9 +1,17 @@
 import type { Tx } from "@/db/client";
-import { usersTable } from "@/db/schema";
+import { userEmailsTable, usersTable } from "@/db/schema";
 import { eq } from "drizzle-orm";
 
 export async function getUserByEmail(tx: Tx, email: string) {
-	return await tx.query.usersTable.findFirst({
-		where: eq(usersTable.email, email),
-	});
+	const [user] = await tx
+		.select({
+			id: usersTable.id,
+			publicId: usersTable.publicId,
+			email: userEmailsTable.email,
+		})
+		.from(usersTable)
+		.innerJoin(userEmailsTable, eq(userEmailsTable.userId, usersTable.id))
+		.where(eq(userEmailsTable.email, email));
+
+	return user ?? null;
 }

--- a/migrations/0021_friendly_nico_minoru.sql
+++ b/migrations/0021_friendly_nico_minoru.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `user_emails_table` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` integer NOT NULL,
+	`email` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users_table`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `user_emails_table` (`user_id`, `email`)
+SELECT `id`, `email`
+FROM `users_table`;--> statement-breakpoint
+CREATE UNIQUE INDEX `user_emails_table_email_unique` ON `user_emails_table` (`email`);--> statement-breakpoint
+DROP INDEX `users_table_email_unique`;--> statement-breakpoint
+ALTER TABLE `users_table` DROP COLUMN `email`;

--- a/migrations/meta/0021_snapshot.json
+++ b/migrations/meta/0021_snapshot.json
@@ -1,0 +1,793 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c179190b-155f-4b6f-a527-302b9e9d65a0",
+  "prevId": "40a0d841-e95b-404d-91da-a09d749ec283",
+  "tables": {
+    "auth_tokens_table": {
+      "name": "auth_tokens_table",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_table_token_unique": {
+          "name": "auth_tokens_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_table_user_id_users_table_id_fk": {
+          "name": "auth_tokens_table_user_id_users_table_id_fk",
+          "tableFrom": "auth_tokens_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "directors_table": {
+      "name": "directors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_items_table": {
+      "name": "list_items_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "listId": {
+          "name": "listId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "streamingServiceId": {
+          "name": "streamingServiceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "watchUrl": {
+          "name": "watchUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watchStatus": {
+          "name": "watchStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "titleOnService": {
+          "name": "titleOnService",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "list_items_table_publicId_unique": {
+          "name": "list_items_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        },
+        "list_items_table_listId_watchUrl_unique": {
+          "name": "list_items_table_listId_watchUrl_unique",
+          "columns": [
+            "listId",
+            "watchUrl"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "list_items_table_listId_lists_table_id_fk": {
+          "name": "list_items_table_listId_lists_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "lists_table",
+          "columnsFrom": [
+            "listId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "list_items_table_streamingServiceId_streaming_services_table_id_fk": {
+          "name": "list_items_table_streamingServiceId_streaming_services_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "streaming_services_table",
+          "columnsFrom": [
+            "streamingServiceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "list_items_table_movieId_movies_table_id_fk": {
+          "name": "list_items_table_movieId_movies_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_movies_table": {
+      "name": "list_movies_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "listId": {
+          "name": "listId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movieServiceId": {
+          "name": "movieServiceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "list_movies_table_listId_lists_table_id_fk": {
+          "name": "list_movies_table_listId_lists_table_id_fk",
+          "tableFrom": "list_movies_table",
+          "tableTo": "lists_table",
+          "columnsFrom": [
+            "listId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "list_movies_table_movieServiceId_movie_services_table_id_fk": {
+          "name": "list_movies_table_movieServiceId_movie_services_table_id_fk",
+          "tableFrom": "list_movies_table",
+          "tableTo": "movie_services_table",
+          "columnsFrom": [
+            "movieServiceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lists_table": {
+      "name": "lists_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "lists_table_publicId_unique": {
+          "name": "lists_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        },
+        "lists_table_userId_unique": {
+          "name": "lists_table_userId_unique",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "lists_table_userId_users_table_id_fk": {
+          "name": "lists_table_userId_users_table_id_fk",
+          "tableFrom": "lists_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "login_attempts_table": {
+      "name": "login_attempts_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_type": {
+          "name": "attempt_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_directors_table": {
+      "name": "movie_directors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "directorId": {
+          "name": "directorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movie_directors_table_movieId_movies_table_id_fk": {
+          "name": "movie_directors_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_directors_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movie_directors_table_directorId_directors_table_id_fk": {
+          "name": "movie_directors_table_directorId_directors_table_id_fk",
+          "tableFrom": "movie_directors_table",
+          "tableTo": "directors_table",
+          "columnsFrom": [
+            "directorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_services_table": {
+      "name": "movie_services_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "streamingServiceId": {
+          "name": "streamingServiceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watchUrl": {
+          "name": "watchUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "titleOnService": {
+          "name": "titleOnService",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movie_services_table_userId_users_table_id_fk": {
+          "name": "movie_services_table_userId_users_table_id_fk",
+          "tableFrom": "movie_services_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movie_services_table_movieId_movies_table_id_fk": {
+          "name": "movie_services_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_services_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movie_services_table_streamingServiceId_streaming_services_table_id_fk": {
+          "name": "movie_services_table_streamingServiceId_streaming_services_table_id_fk",
+          "tableFrom": "movie_services_table",
+          "tableTo": "streaming_services_table",
+          "columnsFrom": [
+            "streamingServiceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies_table": {
+      "name": "movies_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "externalDatabaseMovieId": {
+          "name": "externalDatabaseMovieId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backgroundImage": {
+          "name": "backgroundImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posterImage": {
+          "name": "posterImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runningMinutes": {
+          "name": "runningMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "releaseDate": {
+          "name": "releaseDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "releaseYear": {
+          "name": "releaseYear",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "movies_table_externalDatabaseMovieId_unique": {
+          "name": "movies_table_externalDatabaseMovieId_unique",
+          "columns": [
+            "externalDatabaseMovieId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "streaming_services_table": {
+      "name": "streaming_services_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "streaming_services_table_slug_unique": {
+          "name": "streaming_services_table_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_emails_table": {
+      "name": "user_emails_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_emails_table_email_unique": {
+          "name": "user_emails_table_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_emails_table_user_id_users_table_id_fk": {
+          "name": "user_emails_table_user_id_users_table_id_fk",
+          "tableFrom": "user_emails_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users_table": {
+      "name": "users_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_table_publicId_unique": {
+          "name": "users_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1772692775444,
       "tag": "0020_slippery_blockbuster",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1773809373727,
+      "tag": "0021_friendly_nico_minoru",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -11,6 +11,7 @@ import {
 	movieDirectorsTable,
 	movieServicesTable,
 	listsTable,
+	userEmailsTable,
 	usersTable,
 } from "@/db/schema";
 import { SUPPORTED_SERVICES } from "@/app/consts";
@@ -32,6 +33,7 @@ export async function cleanupTables() {
 	await db.delete(directorsTable);
 	await db.delete(moviesTable);
 	await db.delete(listsTable);
+	await db.delete(userEmailsTable);
 	await db.delete(usersTable);
 }
 
@@ -49,6 +51,7 @@ export async function resetSequences() {
 	await db.run(sql`DELETE FROM sqlite_sequence WHERE name = 'movies_table'`);
 	await db.run(sql`DELETE FROM sqlite_sequence WHERE name = 'directors_table'`);
 	await db.run(sql`DELETE FROM sqlite_sequence WHERE name = 'users_table'`);
+	await db.run(sql`DELETE FROM sqlite_sequence WHERE name = 'user_emails_table'`);
 	await db.run(sql`DELETE FROM sqlite_sequence WHERE name = 'login_attempts_table'`);
 	await db.run(
 		sql`DELETE FROM sqlite_sequence WHERE name = 'movie_services_table'`,


### PR DESCRIPTION
## 変更内容

メールアドレスカラムをユーザーとは別のテーブルへ分離
既存ユーザーのメールアドレスを移行するクエリを追加