### PR TITLE
TMDBからの取得データのキャッシュ日を別テーブルへ分離

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -31,13 +31,26 @@ export const moviesTable = sqliteTable("movies_table", {
 	posterImage: text().notNull(),
 	runningMinutes: int().notNull(),
 	releaseDate: text().notNull(),
-	releaseYear: int().notNull(),
+});
+
+export const movieCacheTable = sqliteTable("movie_cache_table", {
+	movieId: int()
+		.notNull()
+		.primaryKey()
+		.references(() => moviesTable.id),
 	cachedAt: int("cached_at", { mode: "timestamp" }).notNull(),
 });
 
 export const directorsTable = sqliteTable("directors_table", {
 	id: int().primaryKey({ autoIncrement: true }),
 	name: text().notNull(),
+});
+
+export const directorCacheTable = sqliteTable("director_cache_table", {
+	movieId: int()
+		.notNull()
+		.primaryKey()
+		.references(() => moviesTable.id),
 	cachedAt: int("cached_at", { mode: "timestamp" }).notNull(),
 });
 

--- a/features/list/actions/storeListItem.test.ts
+++ b/features/list/actions/storeListItem.test.ts
@@ -3,9 +3,11 @@ import { and, eq } from "drizzle-orm";
 import { beforeEach, describe, expect, it } from "vitest";
 import { db } from "@/db/client";
 import {
+	directorCacheTable,
 	directorsTable,
 	listItemsTable,
 	listsTable,
+	movieCacheTable,
 	movieDirectorsTable,
 	moviesTable,
 	streamingServicesTable,
@@ -142,7 +144,6 @@ async function assertMovieRecordFromTmdbDetails(movie: ListItem) {
 				eq(moviesTable.backgroundImage, movie.details.backgroundImage),
 				eq(moviesTable.posterImage, movie.details.posterImage),
 				eq(moviesTable.runningMinutes, movie.details.runningMinutes),
-				eq(moviesTable.releaseYear, movie.details.releaseYear),
 			),
 		);
 
@@ -152,7 +153,6 @@ async function assertMovieRecordFromTmdbDetails(movie: ListItem) {
 		throw Error("movies_table にTMDB由来のレコードが作成されていません");
 	}
 
-	expect(movieRecord.cachedAt).toBeInstanceOf(Date);
 	return movieRecord;
 }
 
@@ -179,8 +179,37 @@ async function assertDirectorRecordFromTmdbDetails(movie: ListItem) {
 		throw Error("directors_table に監督レコードが作成されていません");
 	}
 
-	expect(directorRecord.cachedAt).toBeInstanceOf(Date);
 	return directorRecord;
+}
+
+async function assertMovieCacheRecord(movieId: number) {
+	const [movieCacheRecord] = await db
+		.select()
+		.from(movieCacheTable)
+		.where(eq(movieCacheTable.movieId, movieId));
+
+	expect(movieCacheRecord).toBeDefined();
+
+	if (!movieCacheRecord) {
+		throw Error("movie_cache_table にキャッシュレコードが作成されていません");
+	}
+
+	expect(movieCacheRecord.cachedAt).toBeInstanceOf(Date);
+}
+
+async function assertDirectorCacheRecord(movieId: number) {
+	const [directorCacheRecord] = await db
+		.select()
+		.from(directorCacheTable)
+		.where(eq(directorCacheTable.movieId, movieId));
+
+	expect(directorCacheRecord).toBeDefined();
+
+	if (!directorCacheRecord) {
+		throw Error("director_cache_table にキャッシュレコードが作成されていません");
+	}
+
+	expect(directorCacheRecord.cachedAt).toBeInstanceOf(Date);
 }
 
 async function assertMovieDirectorRecord({
@@ -286,19 +315,26 @@ describe("storeMovie", () => {
 				posterImage: tmdbMovieDetails.posterImage,
 				runningMinutes: tmdbMovieDetails.runningMinutes,
 				releaseDate: "1993-06-11",
-				releaseYear: tmdbMovieDetails.releaseYear,
-				cachedAt: new Date(),
 				overview: tmdbMovieDetails.overview,
 			})
 			.returning({ id: moviesTable.id });
+
+		await db.insert(movieCacheTable).values({
+			movieId: seededMovie.id,
+			cachedAt: new Date(),
+		});
 
 		const [seededDirector] = await db
 			.insert(directorsTable)
 			.values({
 				name: tmdbMovieDetails.director[0],
-				cachedAt: new Date(),
 			})
 			.returning({ id: directorsTable.id });
+
+		await db.insert(directorCacheTable).values({
+			movieId: seededMovie.id,
+			cachedAt: new Date(),
+		});
 
 		await db.insert(movieDirectorsTable).values({
 			movieId: seededMovie.id,
@@ -325,13 +361,11 @@ describe("storeMovie", () => {
 			expectedTitle: movie.title,
 		});
 		expect(storeResult).not.toBeNull();
-		const details = movie.details;
-		if (!details) {
-			throw Error("TMDBありケースのため movie.details が必要です");
-		}
 
 		const movieRecord = await assertMovieRecordFromTmdbDetails(movie);
 		const directorRecord = await assertDirectorRecordFromTmdbDetails(movie);
+		await assertMovieCacheRecord(movieRecord.id);
+		await assertDirectorCacheRecord(movieRecord.id);
 		await assertMovieDirectorRecord({
 			movieId: movieRecord.id,
 			directorId: directorRecord.id,

--- a/features/list/repositories/server/listRepository.ts
+++ b/features/list/repositories/server/listRepository.ts
@@ -23,7 +23,7 @@ export type ListItemRow = {
 	backgroundImage: string | null;
 	posterImage: string | null;
 	runningMinutes: number | null;
-	releaseYear: number | null;
+	releaseDate: string | null;
 	overview: string | null;
 	externalDatabaseMovieId: string | null;
 };
@@ -170,7 +170,7 @@ export async function findUserListItems(listPublicId: string, userId: number) {
 			backgroundImage: moviesTable.backgroundImage,
 			posterImage: moviesTable.posterImage,
 			runningMinutes: moviesTable.runningMinutes,
-			releaseYear: moviesTable.releaseYear,
+			releaseDate: moviesTable.releaseDate,
 			overview: moviesTable.overview,
 			externalDatabaseMovieId: moviesTable.externalDatabaseMovieId,
 		})

--- a/features/list/services/getUserListService.ts
+++ b/features/list/services/getUserListService.ts
@@ -66,7 +66,7 @@ const mapListItems = (
 			row.backgroundImage === null ||
 			row.posterImage === null ||
 			row.runningMinutes === null ||
-			row.releaseYear === null ||
+			row.releaseDate === null ||
 			row.overview === null ||
 			row.externalDatabaseMovieId === null
 		) {
@@ -96,10 +96,20 @@ const mapListItems = (
 				posterImage: row.posterImage,
 				director: movieDirectors.get(row.movieId) ?? [],
 				runningMinutes: row.runningMinutes,
-				releaseYear: row.releaseYear,
+				releaseYear: getReleaseYear(row.releaseDate),
 				externalDatabaseMovieId: Number(row.externalDatabaseMovieId),
 				overview: row.overview,
 			},
 		};
 	});
+};
+
+const getReleaseYear = (releaseDate: string) => {
+	const releaseYear = new Date(releaseDate).getFullYear();
+
+	if (Number.isNaN(releaseYear)) {
+		throw Error(`releaseDate の形式が不正です: ${releaseDate}`);
+	}
+
+	return releaseYear;
 };

--- a/features/movieDatabase/actions/getDirectorsFromExternalMovieDatabase.ts
+++ b/features/movieDatabase/actions/getDirectorsFromExternalMovieDatabase.ts
@@ -3,6 +3,7 @@
 import { and, eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import {
+	directorCacheTable,
 	directorsTable,
 	movieDirectorsTable,
 	moviesTable,
@@ -29,10 +30,11 @@ export async function getDirectorsFromExternalMovieDatabase(
 	const cachedDirectors = await db
 		.select({
 			name: directorsTable.name,
-			cachedAt: directorsTable.cachedAt,
+			cachedAt: directorCacheTable.cachedAt,
 		})
-		.from(movieDirectorsTable)
-		.innerJoin(moviesTable, eq(movieDirectorsTable.movieId, moviesTable.id))
+		.from(moviesTable)
+		.innerJoin(directorCacheTable, eq(directorCacheTable.movieId, moviesTable.id))
+		.innerJoin(movieDirectorsTable, eq(movieDirectorsTable.movieId, moviesTable.id))
 		.innerJoin(
 			directorsTable,
 			eq(movieDirectorsTable.directorId, directorsTable.id),
@@ -107,17 +109,11 @@ export async function getDirectorsFromExternalMovieDatabase(
 
 				let directorId = existingDirector?.id;
 
-				if (existingDirector) {
-					await tx
-						.update(directorsTable)
-						.set({ cachedAt: now })
-						.where(eq(directorsTable.id, existingDirector.id));
-				} else {
+				if (!existingDirector) {
 					const [insertedDirector] = await tx
 						.insert(directorsTable)
 						.values({
 							name: directorName,
-							cachedAt: now,
 						})
 						.returning({ id: directorsTable.id });
 
@@ -145,6 +141,19 @@ export async function getDirectorsFromExternalMovieDatabase(
 					});
 				}
 			}
+
+			await tx
+				.insert(directorCacheTable)
+				.values({
+					movieId: movie.id,
+					cachedAt: now,
+				})
+				.onConflictDoUpdate({
+					target: directorCacheTable.movieId,
+					set: {
+						cachedAt: now,
+					},
+				});
 		});
 	}
 

--- a/features/movieDatabase/actions/getMovieFromExternalMovieDatabase.ts
+++ b/features/movieDatabase/actions/getMovieFromExternalMovieDatabase.ts
@@ -3,7 +3,7 @@
 import { and, eq, gte } from "drizzle-orm";
 import { TMDB_IMAGE_BASE_URL } from "@/app/consts";
 import { db } from "@/db/client";
-import { moviesTable } from "@/db/schema";
+import { movieCacheTable, moviesTable } from "@/db/schema";
 import type { Result } from "@/features/shared/types/Result";
 import type { TmdbMovieResponse } from "../types/TmdbResponse";
 
@@ -30,10 +30,11 @@ export async function getMovieFromExternalMovieDatabase(
 			overview: moviesTable.overview,
 		})
 		.from(moviesTable)
+		.innerJoin(movieCacheTable, eq(movieCacheTable.movieId, moviesTable.id))
 		.where(
 			and(
 				eq(moviesTable.externalDatabaseMovieId, externalDatabaseMovieId),
-				gte(moviesTable.cachedAt, cacheThreshold),
+				gte(movieCacheTable.cachedAt, cacheThreshold),
 			),
 		);
 
@@ -88,39 +89,55 @@ export async function getMovieFromExternalMovieDatabase(
 	}
 
 	const data: TmdbMovieResponse = await response.json();
-	const releaseYear = new Date(data.release_date).getFullYear();
 
-	await db
-		.insert(moviesTable)
-		.values({
-			externalDatabaseMovieId,
-			title: data.title,
-			backgroundImage: TMDB_IMAGE_BASE_URL + data.backdrop_path,
-			posterImage: TMDB_IMAGE_BASE_URL + data.poster_path,
-			runningMinutes: data.runtime,
-			releaseDate: data.release_date,
-			releaseYear,
-			cachedAt: now,
-			overview: data.overview,
-		})
-		.onConflictDoUpdate({
-			target: moviesTable.externalDatabaseMovieId,
-			set: {
+	const insertedOrUpdatedMovie = await db.transaction(async (tx) => {
+		await tx
+			.insert(moviesTable)
+			.values({
+				externalDatabaseMovieId,
 				title: data.title,
 				backgroundImage: TMDB_IMAGE_BASE_URL + data.backdrop_path,
 				posterImage: TMDB_IMAGE_BASE_URL + data.poster_path,
 				runningMinutes: data.runtime,
 				releaseDate: data.release_date,
-				releaseYear,
-				cachedAt: now,
 				overview: data.overview,
-			},
-		});
+			})
+			.onConflictDoUpdate({
+				target: moviesTable.externalDatabaseMovieId,
+				set: {
+					title: data.title,
+					backgroundImage: TMDB_IMAGE_BASE_URL + data.backdrop_path,
+					posterImage: TMDB_IMAGE_BASE_URL + data.poster_path,
+					runningMinutes: data.runtime,
+					releaseDate: data.release_date,
+					overview: data.overview,
+				},
+			});
 
-	const [insertedOrUpdatedMovie] = await db
-		.select({ movieId: moviesTable.id })
-		.from(moviesTable)
-		.where(eq(moviesTable.externalDatabaseMovieId, externalDatabaseMovieId));
+		const [movie] = await tx
+			.select({ movieId: moviesTable.id })
+			.from(moviesTable)
+			.where(eq(moviesTable.externalDatabaseMovieId, externalDatabaseMovieId));
+
+		if (!movie) {
+			throw Error("movies_table への登録に失敗しました");
+		}
+
+		await tx
+			.insert(movieCacheTable)
+			.values({
+				movieId: movie.movieId,
+				cachedAt: now,
+			})
+			.onConflictDoUpdate({
+				target: movieCacheTable.movieId,
+				set: {
+					cachedAt: now,
+				},
+			});
+
+		return movie;
+	});
 
 	return {
 		success: true,

--- a/migrations/0022_special_virginia_dare.sql
+++ b/migrations/0022_special_virginia_dare.sql
@@ -1,0 +1,26 @@
+CREATE TABLE `director_cache_table` (
+	`movieId` integer PRIMARY KEY NOT NULL,
+	`cached_at` integer NOT NULL,
+	FOREIGN KEY (`movieId`) REFERENCES `movies_table`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `movie_cache_table` (
+	`movieId` integer PRIMARY KEY NOT NULL,
+	`cached_at` integer NOT NULL,
+	FOREIGN KEY (`movieId`) REFERENCES `movies_table`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `movie_cache_table` ("movieId", "cached_at")
+SELECT `id`, `cached_at`
+FROM `movies_table`;--> statement-breakpoint
+INSERT INTO `director_cache_table` ("movieId", "cached_at")
+SELECT
+	`movie_directors_table`.`movieId`,
+	MIN(`directors_table`.`cached_at`)
+FROM `movie_directors_table`
+INNER JOIN `directors_table`
+	ON `movie_directors_table`.`directorId` = `directors_table`.`id`
+GROUP BY `movie_directors_table`.`movieId`;--> statement-breakpoint
+ALTER TABLE `directors_table` DROP COLUMN `cached_at`;--> statement-breakpoint
+ALTER TABLE `movies_table` DROP COLUMN `releaseYear`;--> statement-breakpoint
+ALTER TABLE `movies_table` DROP COLUMN `cached_at`;

--- a/migrations/meta/0022_snapshot.json
+++ b/migrations/meta/0022_snapshot.json
@@ -1,0 +1,848 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "11cd6cd6-1754-401d-90d9-fa157d063cc0",
+  "prevId": "c179190b-155f-4b6f-a527-302b9e9d65a0",
+  "tables": {
+    "auth_tokens_table": {
+      "name": "auth_tokens_table",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_table_token_unique": {
+          "name": "auth_tokens_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_table_user_id_users_table_id_fk": {
+          "name": "auth_tokens_table_user_id_users_table_id_fk",
+          "tableFrom": "auth_tokens_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "director_cache_table": {
+      "name": "director_cache_table",
+      "columns": {
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "director_cache_table_movieId_movies_table_id_fk": {
+          "name": "director_cache_table_movieId_movies_table_id_fk",
+          "tableFrom": "director_cache_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "directors_table": {
+      "name": "directors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_items_table": {
+      "name": "list_items_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "listId": {
+          "name": "listId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "streamingServiceId": {
+          "name": "streamingServiceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "watchUrl": {
+          "name": "watchUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watchStatus": {
+          "name": "watchStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "titleOnService": {
+          "name": "titleOnService",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "list_items_table_publicId_unique": {
+          "name": "list_items_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        },
+        "list_items_table_listId_watchUrl_unique": {
+          "name": "list_items_table_listId_watchUrl_unique",
+          "columns": [
+            "listId",
+            "watchUrl"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "list_items_table_listId_lists_table_id_fk": {
+          "name": "list_items_table_listId_lists_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "lists_table",
+          "columnsFrom": [
+            "listId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "list_items_table_streamingServiceId_streaming_services_table_id_fk": {
+          "name": "list_items_table_streamingServiceId_streaming_services_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "streaming_services_table",
+          "columnsFrom": [
+            "streamingServiceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "list_items_table_movieId_movies_table_id_fk": {
+          "name": "list_items_table_movieId_movies_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_movies_table": {
+      "name": "list_movies_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "listId": {
+          "name": "listId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movieServiceId": {
+          "name": "movieServiceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "list_movies_table_listId_lists_table_id_fk": {
+          "name": "list_movies_table_listId_lists_table_id_fk",
+          "tableFrom": "list_movies_table",
+          "tableTo": "lists_table",
+          "columnsFrom": [
+            "listId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "list_movies_table_movieServiceId_movie_services_table_id_fk": {
+          "name": "list_movies_table_movieServiceId_movie_services_table_id_fk",
+          "tableFrom": "list_movies_table",
+          "tableTo": "movie_services_table",
+          "columnsFrom": [
+            "movieServiceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lists_table": {
+      "name": "lists_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "lists_table_publicId_unique": {
+          "name": "lists_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        },
+        "lists_table_userId_unique": {
+          "name": "lists_table_userId_unique",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "lists_table_userId_users_table_id_fk": {
+          "name": "lists_table_userId_users_table_id_fk",
+          "tableFrom": "lists_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "login_attempts_table": {
+      "name": "login_attempts_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_type": {
+          "name": "attempt_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_cache_table": {
+      "name": "movie_cache_table",
+      "columns": {
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movie_cache_table_movieId_movies_table_id_fk": {
+          "name": "movie_cache_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_cache_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_directors_table": {
+      "name": "movie_directors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "directorId": {
+          "name": "directorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movie_directors_table_movieId_movies_table_id_fk": {
+          "name": "movie_directors_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_directors_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movie_directors_table_directorId_directors_table_id_fk": {
+          "name": "movie_directors_table_directorId_directors_table_id_fk",
+          "tableFrom": "movie_directors_table",
+          "tableTo": "directors_table",
+          "columnsFrom": [
+            "directorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_services_table": {
+      "name": "movie_services_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "streamingServiceId": {
+          "name": "streamingServiceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watchUrl": {
+          "name": "watchUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "titleOnService": {
+          "name": "titleOnService",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movie_services_table_userId_users_table_id_fk": {
+          "name": "movie_services_table_userId_users_table_id_fk",
+          "tableFrom": "movie_services_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movie_services_table_movieId_movies_table_id_fk": {
+          "name": "movie_services_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_services_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movie_services_table_streamingServiceId_streaming_services_table_id_fk": {
+          "name": "movie_services_table_streamingServiceId_streaming_services_table_id_fk",
+          "tableFrom": "movie_services_table",
+          "tableTo": "streaming_services_table",
+          "columnsFrom": [
+            "streamingServiceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies_table": {
+      "name": "movies_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "externalDatabaseMovieId": {
+          "name": "externalDatabaseMovieId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backgroundImage": {
+          "name": "backgroundImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posterImage": {
+          "name": "posterImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runningMinutes": {
+          "name": "runningMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "releaseDate": {
+          "name": "releaseDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "movies_table_externalDatabaseMovieId_unique": {
+          "name": "movies_table_externalDatabaseMovieId_unique",
+          "columns": [
+            "externalDatabaseMovieId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "streaming_services_table": {
+      "name": "streaming_services_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "streaming_services_table_slug_unique": {
+          "name": "streaming_services_table_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_emails_table": {
+      "name": "user_emails_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_emails_table_email_unique": {
+          "name": "user_emails_table_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_emails_table_user_id_users_table_id_fk": {
+          "name": "user_emails_table_user_id_users_table_id_fk",
+          "tableFrom": "user_emails_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users_table": {
+      "name": "users_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_table_publicId_unique": {
+          "name": "users_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1773809373727,
       "tag": "0021_friendly_nico_minoru",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1773815271560,
+      "tag": "0022_special_virginia_dare",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -2,9 +2,11 @@ import { db } from "@/db/client";
 import { sql } from "drizzle-orm";
 import {
 	authTokensTable,
+	directorCacheTable,
 	directorsTable,
 	listItemsTable,
 	loginAttemptsTable,
+	movieCacheTable,
 	moviesTable,
 	streamingServicesTable,
 	listMoviesTable,
@@ -28,9 +30,11 @@ export async function cleanupTables() {
 	await db.delete(authTokensTable);
 	await db.delete(listItemsTable);
 	await db.delete(listMoviesTable);
+	await db.delete(directorCacheTable);
 	await db.delete(movieDirectorsTable);
 	await db.delete(movieServicesTable);
 	await db.delete(directorsTable);
+	await db.delete(movieCacheTable);
 	await db.delete(moviesTable);
 	await db.delete(listsTable);
 	await db.delete(userEmailsTable);


### PR DESCRIPTION
## 変更内容

TMDBから取得したデータをキャッシュする映画テーブル / 監督テーブルのスキーマ変更。
キャッシュ日付のカラムを削除し、これを管理する別テーブルを追加。