### PR TITLE
リストアイテムと映画マスタの紐付け / 視聴ステータスの管理を別テーブルへ切り出し

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -73,19 +73,6 @@ export const movieDirectorsTable = sqliteTable(
 	],
 );
 
-export const movieServicesTable = sqliteTable("movie_services_table", {
-	id: int().primaryKey({ autoIncrement: true }),
-	userId: int()
-		.notNull()
-		.references(() => usersTable.id),
-	movieId: int().references(() => moviesTable.id),
-	streamingServiceId: int()
-		.notNull()
-		.references(() => streamingServicesTable.id),
-	watchUrl: text().notNull(),
-	titleOnService: text().notNull(),
-});
-
 export const listsTable = sqliteTable("lists_table", {
 	id: int().primaryKey({ autoIncrement: true }),
 	publicId: text().notNull().unique(),
@@ -106,9 +93,7 @@ export const listItemsTable = sqliteTable(
 		streamingServiceId: int()
 			.notNull()
 			.references(() => streamingServicesTable.id),
-		movieId: int().references(() => moviesTable.id),
 		watchUrl: text().notNull(),
-		watchStatus: int().notNull().$type<0 | 1>().default(0),
 		titleOnService: text().notNull(),
 		createdAt: int("created_at", { mode: "timestamp" }).notNull(),
 	},
@@ -120,14 +105,29 @@ export const listItemsTable = sqliteTable(
 	],
 );
 
-export const listMoviesTable = sqliteTable("list_movies_table", {
-	id: int().primaryKey({ autoIncrement: true }),
-	listId: int()
+export const listItemMovieMatchTable = sqliteTable(
+	"list_item_movie_match_table",
+	{
+		listItemId: int("list_item_id")
+			.notNull()
+			.primaryKey()
+			.references(() => listItemsTable.id, {
+				onDelete: "cascade",
+			}),
+		movieId: int("movie_id")
+			.notNull()
+			.references(() => moviesTable.id),
+	},
+);
+
+export const watchedItemsTable = sqliteTable("watched_items_table", {
+	listItemId: int("list_item_id")
 		.notNull()
-		.references(() => listsTable.id),
-	movieServiceId: int()
-		.notNull()
-		.references(() => movieServicesTable.id),
+		.primaryKey()
+		.references(() => listItemsTable.id, {
+			onDelete: "cascade",
+		}),
+	watchedAt: int("watched_at", { mode: "timestamp" }).notNull(),
 });
 
 export const authTokensTable = sqliteTable("auth_tokens_table", {

--- a/features/list/actions/getCurrentUserMovieList.test.ts
+++ b/features/list/actions/getCurrentUserMovieList.test.ts
@@ -10,6 +10,7 @@ import {
 	streamingServicesTable,
 	userEmailsTable,
 	usersTable,
+	watchedItemsTable,
 } from "@/db/schema";
 import { getSecretKey } from "@/lib/jwt";
 import { getCurrentUserMovieList } from "./getCurrentUserMovieList";
@@ -169,16 +170,14 @@ describe("getCurrentUserMovieList", () => {
 		const netflixId = await findStreamingServiceIdBySlug("netflix");
 		const huluId = await findStreamingServiceIdBySlug("hulu");
 
-		await db.insert(listItemsTable).values([
+		const insertedListItems = await db.insert(listItemsTable).values([
 			{
 				publicId: "get-current-user-movie-list-user-a-item-1",
 				listId: userAList.id,
 				streamingServiceId: netflixId,
 				watchUrl: "https://www.netflix.com/jp/title/60002360",
 				titleOnService: "ユーザーAの映画1",
-				watchStatus: 0,
 				createdAt: new Date("2026-03-12T00:00:00.000Z"),
-				movieId: null,
 			},
 			{
 				publicId: "get-current-user-movie-list-user-a-item-2",
@@ -186,9 +185,7 @@ describe("getCurrentUserMovieList", () => {
 				streamingServiceId: huluId,
 				watchUrl: "https://www.hulu.jp/watch/test-user-a",
 				titleOnService: "ユーザーAの映画2",
-				watchStatus: 1,
 				createdAt: new Date("2026-03-11T00:00:00.000Z"),
-				movieId: null,
 			},
 			{
 				publicId: "get-current-user-movie-list-user-b-item-1",
@@ -196,11 +193,25 @@ describe("getCurrentUserMovieList", () => {
 				streamingServiceId: netflixId,
 				watchUrl: "https://www.netflix.com/jp/title/80100172",
 				titleOnService: "ユーザーBの映画1",
-				watchStatus: 0,
 				createdAt: new Date("2026-03-10T00:00:00.000Z"),
-				movieId: null,
 			},
-		]);
+		]).returning({
+			id: listItemsTable.id,
+			publicId: listItemsTable.publicId,
+		});
+
+		const watchedListItem = insertedListItems.find(
+			(item) => item.publicId === "get-current-user-movie-list-user-a-item-2",
+		);
+
+		if (!watchedListItem) {
+			throw Error("視聴済みテストデータの作成に失敗しました");
+		}
+
+		await db.insert(watchedItemsTable).values({
+			listItemId: watchedListItem.id,
+			watchedAt: new Date("2026-03-11T00:00:00.000Z"),
+		});
 	});
 
 	it("ログイン中ユーザーは自身のリストアイテム全件を取得できる", async () => {

--- a/features/list/actions/getUserMovieList.test.ts
+++ b/features/list/actions/getUserMovieList.test.ts
@@ -8,6 +8,7 @@ import {
 	streamingServicesTable,
 	userEmailsTable,
 	usersTable,
+	watchedItemsTable,
 } from "@/db/schema";
 import { getUserMovieList } from "./getUserMovieList";
 
@@ -84,16 +85,14 @@ describe("getUserMovieList", () => {
 		const netflixId = await findStreamingServiceIdBySlug("netflix");
 		const huluId = await findStreamingServiceIdBySlug("hulu");
 
-		await db.insert(listItemsTable).values([
+		const insertedListItems = await db.insert(listItemsTable).values([
 			{
 				publicId: "get-user-movie-list-user-a-item-1",
 				listId: userAList.id,
 				streamingServiceId: netflixId,
 				watchUrl: "https://www.netflix.com/jp/title/60002360",
 				titleOnService: "ユーザーAの映画1",
-				watchStatus: 0,
 				createdAt: new Date("2026-03-12T00:00:00.000Z"),
-				movieId: null,
 			},
 			{
 				publicId: "get-user-movie-list-user-a-item-2",
@@ -101,9 +100,7 @@ describe("getUserMovieList", () => {
 				streamingServiceId: huluId,
 				watchUrl: "https://www.hulu.jp/watch/test-user-a",
 				titleOnService: "ユーザーAの映画2",
-				watchStatus: 1,
 				createdAt: new Date("2026-03-11T00:00:00.000Z"),
-				movieId: null,
 			},
 			{
 				publicId: "get-user-movie-list-user-b-item-1",
@@ -111,11 +108,25 @@ describe("getUserMovieList", () => {
 				streamingServiceId: netflixId,
 				watchUrl: "https://www.netflix.com/jp/title/80100172",
 				titleOnService: "ユーザーBの映画1",
-				watchStatus: 0,
 				createdAt: new Date("2026-03-10T00:00:00.000Z"),
-				movieId: null,
 			},
-		]);
+		]).returning({
+			id: listItemsTable.id,
+			publicId: listItemsTable.publicId,
+		});
+
+		const watchedListItem = insertedListItems.find(
+			(item) => item.publicId === "get-user-movie-list-user-a-item-2",
+		);
+
+		if (!watchedListItem) {
+			throw Error("視聴済みテストデータの作成に失敗しました");
+		}
+
+		await db.insert(watchedItemsTable).values({
+			listItemId: watchedListItem.id,
+			watchedAt: new Date("2026-03-11T00:00:00.000Z"),
+		});
 	});
 
 	it("ユーザーは自身のリストアイテム全件を取得できる", async () => {

--- a/features/list/actions/removeListItem.test.ts
+++ b/features/list/actions/removeListItem.test.ts
@@ -54,9 +54,7 @@ describe("removeListItem", () => {
 			streamingServiceId: testStreamingServiceId,
 			watchUrl: "https://www.netflix.com/jp/title/80100172",
 			titleOnService: "テスト映画",
-			watchStatus: 0,
 			createdAt: new Date(),
-			movieId: null,
 		});
 
 		const result = await removeListItem({ listItemId: listItemPublicId });

--- a/features/list/actions/storeListItem.test.ts
+++ b/features/list/actions/storeListItem.test.ts
@@ -5,6 +5,7 @@ import { db } from "@/db/client";
 import {
 	directorCacheTable,
 	directorsTable,
+	listItemMovieMatchTable,
 	listItemsTable,
 	listsTable,
 	movieCacheTable,
@@ -95,13 +96,11 @@ async function assertListItemRecord({
 	testListId,
 	streamingServiceId,
 	movie,
-	expectedMovieId,
 	expectedTitleOnService,
 }: {
 	testListId: number;
 	streamingServiceId: number;
 	movie: ListItem;
-	expectedMovieId: number | null;
 	expectedTitleOnService: string;
 }) {
 	const [listItemRecord] = await db
@@ -122,8 +121,33 @@ async function assertListItemRecord({
 		return null;
 	}
 
-	expect(listItemRecord.movieId).toBe(expectedMovieId);
 	return listItemRecord.id;
+}
+
+async function assertListItemMovieMatchRecord({
+	listItemId,
+	expectedMovieId,
+}: {
+	listItemId: number;
+	expectedMovieId: number | null;
+}) {
+	const [matchRecord] = await db
+		.select()
+		.from(listItemMovieMatchTable)
+		.where(eq(listItemMovieMatchTable.listItemId, listItemId));
+
+	if (expectedMovieId === null) {
+		expect(matchRecord).toBeUndefined();
+		return;
+	}
+
+	expect(matchRecord).toBeDefined();
+
+	if (!matchRecord) {
+		throw Error("list_item_movie_match_table に映画紐付けが作成されていません");
+	}
+
+	expect(matchRecord.movieId).toBe(expectedMovieId);
 }
 
 async function assertMovieRecordFromTmdbDetails(movie: ListItem) {
@@ -284,12 +308,15 @@ describe("storeMovie", () => {
 			testListId,
 			streamingServiceId: netflixStreamingServiceId,
 			movie,
-			expectedMovieId: null,
 			expectedTitleOnService: movie.title,
 		});
 		if (!listItemId) {
 			throw Error("list_items_table へのレコード登録に失敗しています");
 		}
+		await assertListItemMovieMatchRecord({
+			listItemId,
+			expectedMovieId: null,
+		});
 	});
 
 	it("配信作品の情報＋マスタの情報を紐づけて新規登録できる", async () => {
@@ -374,12 +401,18 @@ describe("storeMovie", () => {
 		const streamingServiceId = await getStreamingServiceIdBySlug(
 			movie.serviceSlug,
 		);
-		await assertListItemRecord({
+		const listItemId = await assertListItemRecord({
 			testListId,
 			streamingServiceId,
 			movie,
-			expectedMovieId: movieRecord.id,
 			expectedTitleOnService: movie.title,
+		});
+		if (!listItemId) {
+			throw Error("list_items_table へのレコード登録に失敗しています");
+		}
+		await assertListItemMovieMatchRecord({
+			listItemId,
+			expectedMovieId: movieRecord.id,
 		});
 	});
 

--- a/features/list/repositories/server/listRepository.ts
+++ b/features/list/repositories/server/listRepository.ts
@@ -2,11 +2,13 @@ import { and, desc, eq, inArray } from "drizzle-orm";
 import { db } from "@/db/client";
 import {
 	directorsTable,
+	listItemMovieMatchTable,
 	listItemsTable,
 	listsTable,
 	movieDirectorsTable,
 	moviesTable,
 	streamingServicesTable,
+	watchedItemsTable,
 } from "@/db/schema";
 import type { ListItem } from "@/features/list/types/ListItem";
 
@@ -17,7 +19,7 @@ export type ListItemRow = {
 	createdAt: Date;
 	serviceSlug: ListItem["serviceSlug"];
 	serviceName: ListItem["serviceName"];
-	watchStatus: 0 | 1;
+	watchedAt: Date | null;
 	movieId: number | null;
 	officialTitle: string | null;
 	backgroundImage: string | null;
@@ -78,21 +80,48 @@ export async function updateListItemByPublicIdAndListId({
 	watchStatus: 0 | 1;
 	titleOnService: string;
 }) {
-	await db
-		.update(listItemsTable)
-		.set({
-			streamingServiceId,
-			movieId,
-			watchUrl,
-			watchStatus,
-			titleOnService,
-		})
-		.where(
-			and(
-				eq(listItemsTable.publicId, listItemPublicId),
-				eq(listItemsTable.listId, listId),
-			),
-		);
+	await db.transaction(async (tx) => {
+		const [updatedListItem] = await tx
+			.update(listItemsTable)
+			.set({
+				streamingServiceId,
+				watchUrl,
+				titleOnService,
+			})
+			.where(
+				and(
+					eq(listItemsTable.publicId, listItemPublicId),
+					eq(listItemsTable.listId, listId),
+				),
+			)
+			.returning({ id: listItemsTable.id });
+
+		if (!updatedListItem) {
+			return;
+		}
+
+		await tx
+			.delete(listItemMovieMatchTable)
+			.where(eq(listItemMovieMatchTable.listItemId, updatedListItem.id));
+
+		if (movieId !== null) {
+			await tx.insert(listItemMovieMatchTable).values({
+				listItemId: updatedListItem.id,
+				movieId,
+			});
+		}
+
+		await tx
+			.delete(watchedItemsTable)
+			.where(eq(watchedItemsTable.listItemId, updatedListItem.id));
+
+		if (watchStatus === 1) {
+			await tx.insert(watchedItemsTable).values({
+				listItemId: updatedListItem.id,
+				watchedAt: new Date(),
+			});
+		}
+	});
 }
 
 export async function insertListItem({
@@ -114,15 +143,32 @@ export async function insertListItem({
 	titleOnService: string;
 	createdAt: Date;
 }) {
-	await db.insert(listItemsTable).values({
-		listId,
-		publicId: listItemPublicId,
-		streamingServiceId,
-		movieId,
-		watchUrl,
-		watchStatus,
-		titleOnService,
-		createdAt,
+	await db.transaction(async (tx) => {
+		const [insertedListItem] = await tx
+			.insert(listItemsTable)
+			.values({
+				listId,
+				publicId: listItemPublicId,
+				streamingServiceId,
+				watchUrl,
+				titleOnService,
+				createdAt,
+			})
+			.returning({ id: listItemsTable.id });
+
+		if (movieId !== null) {
+			await tx.insert(listItemMovieMatchTable).values({
+				listItemId: insertedListItem.id,
+				movieId,
+			});
+		}
+
+		if (watchStatus === 1) {
+			await tx.insert(watchedItemsTable).values({
+				listItemId: insertedListItem.id,
+				watchedAt: createdAt,
+			});
+		}
 	});
 }
 
@@ -164,8 +210,8 @@ export async function findUserListItems(listPublicId: string, userId: number) {
 			createdAt: listItemsTable.createdAt,
 			serviceSlug: streamingServicesTable.slug,
 			serviceName: streamingServicesTable.name,
-			watchStatus: listItemsTable.watchStatus,
-			movieId: listItemsTable.movieId,
+			watchedAt: watchedItemsTable.watchedAt,
+			movieId: listItemMovieMatchTable.movieId,
 			officialTitle: moviesTable.title,
 			backgroundImage: moviesTable.backgroundImage,
 			posterImage: moviesTable.posterImage,
@@ -180,7 +226,12 @@ export async function findUserListItems(listPublicId: string, userId: number) {
 			eq(listItemsTable.streamingServiceId, streamingServicesTable.id),
 		)
 		.innerJoin(listsTable, eq(listItemsTable.listId, listsTable.id))
-		.leftJoin(moviesTable, eq(listItemsTable.movieId, moviesTable.id))
+		.leftJoin(
+			listItemMovieMatchTable,
+			eq(listItemMovieMatchTable.listItemId, listItemsTable.id),
+		)
+		.leftJoin(moviesTable, eq(listItemMovieMatchTable.movieId, moviesTable.id))
+		.leftJoin(watchedItemsTable, eq(watchedItemsTable.listItemId, listItemsTable.id))
 		.where(
 			and(eq(listsTable.publicId, listPublicId), eq(listsTable.userId, userId)),
 		)

--- a/features/list/services/getUserListService.ts
+++ b/features/list/services/getUserListService.ts
@@ -77,7 +77,7 @@ const mapListItems = (
 				createdAt: row.createdAt,
 				serviceSlug: row.serviceSlug,
 				serviceName: row.serviceName,
-				isWatched: row.watchStatus === 1,
+				isWatched: row.watchedAt !== null,
 			};
 		}
 
@@ -88,7 +88,7 @@ const mapListItems = (
 			createdAt: row.createdAt,
 			serviceSlug: row.serviceSlug,
 			serviceName: row.serviceName,
-			isWatched: row.watchStatus === 1,
+			isWatched: row.watchedAt !== null,
 			details: {
 				movieId: row.movieId,
 				officialTitle: row.officialTitle,

--- a/features/user/actions/registerUser.ts
+++ b/features/user/actions/registerUser.ts
@@ -9,8 +9,10 @@ import {
 	userEmailsTable,
 	listsTable,
 	authTokensTable,
+	listItemMovieMatchTable,
 	listItemsTable,
 	streamingServicesTable,
+	watchedItemsTable,
 } from "@/db/schema";
 import type { Result } from "@/features/shared/types/Result";
 import { userIdSchema } from "../schemas/userIdSchema";
@@ -157,6 +159,8 @@ export async function registerUser({
 				);
 				const seenWatchUrls = new Set<string>();
 				const listItems: Array<typeof listItemsTable.$inferInsert> = [];
+				const movieIdsByPublicId = new Map<string, number>();
+				const watchedItemPublicIds = new Set<string>();
 
 				for (const item of validLocalListItems) {
 					if (seenWatchUrls.has(item.url)) {
@@ -173,16 +177,54 @@ export async function registerUser({
 						publicId: item.listItemId,
 						listId: newList.id,
 						streamingServiceId,
-						movieId: item.details?.movieId ?? null,
 						watchUrl: item.url,
-						watchStatus: item.isWatched ? 1 : 0,
 						titleOnService: item.title,
 						createdAt: normalizeCreatedAt(item.createdAt, now),
 					});
+
+					if (item.details) {
+						movieIdsByPublicId.set(item.listItemId, item.details.movieId);
+					}
+
+					if (item.isWatched) {
+						watchedItemPublicIds.add(item.listItemId);
+					}
 				}
 
 				if (listItems.length > 0) {
-					await tx.insert(listItemsTable).values(listItems);
+					const insertedListItems = await tx
+						.insert(listItemsTable)
+						.values(listItems)
+						.returning({
+							id: listItemsTable.id,
+							publicId: listItemsTable.publicId,
+							createdAt: listItemsTable.createdAt,
+						});
+
+					const matchedMovies = insertedListItems.flatMap((item) => {
+						const movieId = movieIdsByPublicId.get(item.publicId);
+						if (movieId === undefined) {
+							return [];
+						}
+
+						return [{ listItemId: item.id, movieId }];
+					});
+
+					if (matchedMovies.length > 0) {
+						await tx.insert(listItemMovieMatchTable).values(matchedMovies);
+					}
+
+					const watchedItems = insertedListItems.flatMap((item) => {
+						if (!watchedItemPublicIds.has(item.publicId)) {
+							return [];
+						}
+
+						return [{ listItemId: item.id, watchedAt: item.createdAt }];
+					});
+
+					if (watchedItems.length > 0) {
+						await tx.insert(watchedItemsTable).values(watchedItems);
+					}
 				}
 			}
 

--- a/migrations/0024_panoramic_puff_adder.sql
+++ b/migrations/0024_panoramic_puff_adder.sql
@@ -1,0 +1,40 @@
+CREATE TABLE `list_item_movie_match_table` (
+	`list_item_id` integer PRIMARY KEY NOT NULL,
+	`movie_id` integer NOT NULL,
+	FOREIGN KEY (`list_item_id`) REFERENCES `list_items_table`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`movie_id`) REFERENCES `movies_table`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `watched_items_table` (
+	`list_item_id` integer PRIMARY KEY NOT NULL,
+	`watched_at` integer NOT NULL,
+	FOREIGN KEY (`list_item_id`) REFERENCES `list_items_table`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_list_items_table` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`publicId` text NOT NULL,
+	`listId` integer NOT NULL,
+	`streamingServiceId` integer NOT NULL,
+	`watchUrl` text NOT NULL,
+	`titleOnService` text NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`listId`) REFERENCES `lists_table`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`streamingServiceId`) REFERENCES `streaming_services_table`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `list_item_movie_match_table`("list_item_id", "movie_id")
+SELECT `id`, `movieId`
+FROM `list_items_table`
+WHERE `movieId` IS NOT NULL;--> statement-breakpoint
+INSERT INTO `watched_items_table`("list_item_id", "watched_at")
+SELECT `id`, `created_at`
+FROM `list_items_table`
+WHERE `watchStatus` = 1;--> statement-breakpoint
+INSERT INTO `__new_list_items_table`("id", "publicId", "listId", "streamingServiceId", "watchUrl", "titleOnService", "created_at") SELECT "id", "publicId", "listId", "streamingServiceId", "watchUrl", "titleOnService", "created_at" FROM `list_items_table`;--> statement-breakpoint
+DROP TABLE `list_items_table`;--> statement-breakpoint
+ALTER TABLE `__new_list_items_table` RENAME TO `list_items_table`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `list_items_table_publicId_unique` ON `list_items_table` (`publicId`);--> statement-breakpoint
+CREATE UNIQUE INDEX `list_items_table_listId_watchUrl_unique` ON `list_items_table` (`listId`,`watchUrl`);

--- a/migrations/0025_curved_makkari.sql
+++ b/migrations/0025_curved_makkari.sql
@@ -1,0 +1,2 @@
+DROP TABLE `list_movies_table`;--> statement-breakpoint
+DROP TABLE `movie_services_table`;

--- a/migrations/meta/0024_snapshot.json
+++ b/migrations/meta/0024_snapshot.json
@@ -1,0 +1,918 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1efe783f-1356-485c-8353-b1755a0d6191",
+  "prevId": "2a679dbf-a11e-484c-911b-40f98e9a0da5",
+  "tables": {
+    "auth_tokens_table": {
+      "name": "auth_tokens_table",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_table_token_unique": {
+          "name": "auth_tokens_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_table_user_id_users_table_id_fk": {
+          "name": "auth_tokens_table_user_id_users_table_id_fk",
+          "tableFrom": "auth_tokens_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "director_cache_table": {
+      "name": "director_cache_table",
+      "columns": {
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "director_cache_table_movieId_movies_table_id_fk": {
+          "name": "director_cache_table_movieId_movies_table_id_fk",
+          "tableFrom": "director_cache_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "directors_table": {
+      "name": "directors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_item_movie_match_table": {
+      "name": "list_item_movie_match_table",
+      "columns": {
+        "list_item_id": {
+          "name": "list_item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "list_item_movie_match_table_list_item_id_list_items_table_id_fk": {
+          "name": "list_item_movie_match_table_list_item_id_list_items_table_id_fk",
+          "tableFrom": "list_item_movie_match_table",
+          "tableTo": "list_items_table",
+          "columnsFrom": [
+            "list_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_item_movie_match_table_movie_id_movies_table_id_fk": {
+          "name": "list_item_movie_match_table_movie_id_movies_table_id_fk",
+          "tableFrom": "list_item_movie_match_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_items_table": {
+      "name": "list_items_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "listId": {
+          "name": "listId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "streamingServiceId": {
+          "name": "streamingServiceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watchUrl": {
+          "name": "watchUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "titleOnService": {
+          "name": "titleOnService",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "list_items_table_publicId_unique": {
+          "name": "list_items_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        },
+        "list_items_table_listId_watchUrl_unique": {
+          "name": "list_items_table_listId_watchUrl_unique",
+          "columns": [
+            "listId",
+            "watchUrl"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "list_items_table_listId_lists_table_id_fk": {
+          "name": "list_items_table_listId_lists_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "lists_table",
+          "columnsFrom": [
+            "listId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "list_items_table_streamingServiceId_streaming_services_table_id_fk": {
+          "name": "list_items_table_streamingServiceId_streaming_services_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "streaming_services_table",
+          "columnsFrom": [
+            "streamingServiceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_movies_table": {
+      "name": "list_movies_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "listId": {
+          "name": "listId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movieServiceId": {
+          "name": "movieServiceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "list_movies_table_listId_lists_table_id_fk": {
+          "name": "list_movies_table_listId_lists_table_id_fk",
+          "tableFrom": "list_movies_table",
+          "tableTo": "lists_table",
+          "columnsFrom": [
+            "listId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "list_movies_table_movieServiceId_movie_services_table_id_fk": {
+          "name": "list_movies_table_movieServiceId_movie_services_table_id_fk",
+          "tableFrom": "list_movies_table",
+          "tableTo": "movie_services_table",
+          "columnsFrom": [
+            "movieServiceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lists_table": {
+      "name": "lists_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "lists_table_publicId_unique": {
+          "name": "lists_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        },
+        "lists_table_userId_unique": {
+          "name": "lists_table_userId_unique",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "lists_table_userId_users_table_id_fk": {
+          "name": "lists_table_userId_users_table_id_fk",
+          "tableFrom": "lists_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "login_attempts_table": {
+      "name": "login_attempts_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_type": {
+          "name": "attempt_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_cache_table": {
+      "name": "movie_cache_table",
+      "columns": {
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movie_cache_table_movieId_movies_table_id_fk": {
+          "name": "movie_cache_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_cache_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_directors_table": {
+      "name": "movie_directors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "directorId": {
+          "name": "directorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "movie_directors_movie_id_director_id_unique": {
+          "name": "movie_directors_movie_id_director_id_unique",
+          "columns": [
+            "movieId",
+            "directorId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "movie_directors_table_movieId_movies_table_id_fk": {
+          "name": "movie_directors_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_directors_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movie_directors_table_directorId_directors_table_id_fk": {
+          "name": "movie_directors_table_directorId_directors_table_id_fk",
+          "tableFrom": "movie_directors_table",
+          "tableTo": "directors_table",
+          "columnsFrom": [
+            "directorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_services_table": {
+      "name": "movie_services_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "streamingServiceId": {
+          "name": "streamingServiceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watchUrl": {
+          "name": "watchUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "titleOnService": {
+          "name": "titleOnService",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movie_services_table_userId_users_table_id_fk": {
+          "name": "movie_services_table_userId_users_table_id_fk",
+          "tableFrom": "movie_services_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movie_services_table_movieId_movies_table_id_fk": {
+          "name": "movie_services_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_services_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movie_services_table_streamingServiceId_streaming_services_table_id_fk": {
+          "name": "movie_services_table_streamingServiceId_streaming_services_table_id_fk",
+          "tableFrom": "movie_services_table",
+          "tableTo": "streaming_services_table",
+          "columnsFrom": [
+            "streamingServiceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies_table": {
+      "name": "movies_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "externalDatabaseMovieId": {
+          "name": "externalDatabaseMovieId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backgroundImage": {
+          "name": "backgroundImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posterImage": {
+          "name": "posterImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runningMinutes": {
+          "name": "runningMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "releaseDate": {
+          "name": "releaseDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "movies_table_externalDatabaseMovieId_unique": {
+          "name": "movies_table_externalDatabaseMovieId_unique",
+          "columns": [
+            "externalDatabaseMovieId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "streaming_services_table": {
+      "name": "streaming_services_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "streaming_services_table_slug_unique": {
+          "name": "streaming_services_table_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_emails_table": {
+      "name": "user_emails_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_emails_table_email_unique": {
+          "name": "user_emails_table_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_emails_table_user_id_users_table_id_fk": {
+          "name": "user_emails_table_user_id_users_table_id_fk",
+          "tableFrom": "user_emails_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users_table": {
+      "name": "users_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_table_publicId_unique": {
+          "name": "users_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watched_items_table": {
+      "name": "watched_items_table",
+      "columns": {
+        "list_item_id": {
+          "name": "list_item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watched_at": {
+          "name": "watched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watched_items_table_list_item_id_list_items_table_id_fk": {
+          "name": "watched_items_table_list_item_id_list_items_table_id_fk",
+          "tableFrom": "watched_items_table",
+          "tableTo": "list_items_table",
+          "columnsFrom": [
+            "list_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/0025_snapshot.json
+++ b/migrations/meta/0025_snapshot.json
@@ -1,0 +1,768 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "15411c22-766a-4e3b-82f8-a5515e829f83",
+  "prevId": "1efe783f-1356-485c-8353-b1755a0d6191",
+  "tables": {
+    "auth_tokens_table": {
+      "name": "auth_tokens_table",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_table_token_unique": {
+          "name": "auth_tokens_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_table_user_id_users_table_id_fk": {
+          "name": "auth_tokens_table_user_id_users_table_id_fk",
+          "tableFrom": "auth_tokens_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "director_cache_table": {
+      "name": "director_cache_table",
+      "columns": {
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "director_cache_table_movieId_movies_table_id_fk": {
+          "name": "director_cache_table_movieId_movies_table_id_fk",
+          "tableFrom": "director_cache_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "directors_table": {
+      "name": "directors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_item_movie_match_table": {
+      "name": "list_item_movie_match_table",
+      "columns": {
+        "list_item_id": {
+          "name": "list_item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "list_item_movie_match_table_list_item_id_list_items_table_id_fk": {
+          "name": "list_item_movie_match_table_list_item_id_list_items_table_id_fk",
+          "tableFrom": "list_item_movie_match_table",
+          "tableTo": "list_items_table",
+          "columnsFrom": [
+            "list_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_item_movie_match_table_movie_id_movies_table_id_fk": {
+          "name": "list_item_movie_match_table_movie_id_movies_table_id_fk",
+          "tableFrom": "list_item_movie_match_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_items_table": {
+      "name": "list_items_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "listId": {
+          "name": "listId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "streamingServiceId": {
+          "name": "streamingServiceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watchUrl": {
+          "name": "watchUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "titleOnService": {
+          "name": "titleOnService",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "list_items_table_publicId_unique": {
+          "name": "list_items_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        },
+        "list_items_table_listId_watchUrl_unique": {
+          "name": "list_items_table_listId_watchUrl_unique",
+          "columns": [
+            "listId",
+            "watchUrl"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "list_items_table_listId_lists_table_id_fk": {
+          "name": "list_items_table_listId_lists_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "lists_table",
+          "columnsFrom": [
+            "listId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "list_items_table_streamingServiceId_streaming_services_table_id_fk": {
+          "name": "list_items_table_streamingServiceId_streaming_services_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "streaming_services_table",
+          "columnsFrom": [
+            "streamingServiceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lists_table": {
+      "name": "lists_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "lists_table_publicId_unique": {
+          "name": "lists_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        },
+        "lists_table_userId_unique": {
+          "name": "lists_table_userId_unique",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "lists_table_userId_users_table_id_fk": {
+          "name": "lists_table_userId_users_table_id_fk",
+          "tableFrom": "lists_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "login_attempts_table": {
+      "name": "login_attempts_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_type": {
+          "name": "attempt_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_cache_table": {
+      "name": "movie_cache_table",
+      "columns": {
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movie_cache_table_movieId_movies_table_id_fk": {
+          "name": "movie_cache_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_cache_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_directors_table": {
+      "name": "movie_directors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "directorId": {
+          "name": "directorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "movie_directors_movie_id_director_id_unique": {
+          "name": "movie_directors_movie_id_director_id_unique",
+          "columns": [
+            "movieId",
+            "directorId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "movie_directors_table_movieId_movies_table_id_fk": {
+          "name": "movie_directors_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_directors_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movie_directors_table_directorId_directors_table_id_fk": {
+          "name": "movie_directors_table_directorId_directors_table_id_fk",
+          "tableFrom": "movie_directors_table",
+          "tableTo": "directors_table",
+          "columnsFrom": [
+            "directorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies_table": {
+      "name": "movies_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "externalDatabaseMovieId": {
+          "name": "externalDatabaseMovieId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backgroundImage": {
+          "name": "backgroundImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posterImage": {
+          "name": "posterImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runningMinutes": {
+          "name": "runningMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "releaseDate": {
+          "name": "releaseDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "movies_table_externalDatabaseMovieId_unique": {
+          "name": "movies_table_externalDatabaseMovieId_unique",
+          "columns": [
+            "externalDatabaseMovieId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "streaming_services_table": {
+      "name": "streaming_services_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "streaming_services_table_slug_unique": {
+          "name": "streaming_services_table_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_emails_table": {
+      "name": "user_emails_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_emails_table_email_unique": {
+          "name": "user_emails_table_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_emails_table_user_id_users_table_id_fk": {
+          "name": "user_emails_table_user_id_users_table_id_fk",
+          "tableFrom": "user_emails_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users_table": {
+      "name": "users_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_table_publicId_unique": {
+          "name": "users_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watched_items_table": {
+      "name": "watched_items_table",
+      "columns": {
+        "list_item_id": {
+          "name": "list_item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watched_at": {
+          "name": "watched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watched_items_table_list_item_id_list_items_table_id_fk": {
+          "name": "watched_items_table_list_item_id_list_items_table_id_fk",
+          "tableFrom": "watched_items_table",
+          "tableTo": "list_items_table",
+          "columnsFrom": [
+            "list_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -169,6 +169,20 @@
       "when": 1773821198307,
       "tag": "0023_massive_ronan",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "6",
+      "when": 1773823742218,
+      "tag": "0024_panoramic_puff_adder",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "6",
+      "when": 1773824600673,
+      "tag": "0025_curved_makkari",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -4,17 +4,17 @@ import {
 	authTokensTable,
 	directorCacheTable,
 	directorsTable,
+	listItemMovieMatchTable,
 	listItemsTable,
 	loginAttemptsTable,
 	movieCacheTable,
 	moviesTable,
 	streamingServicesTable,
-	listMoviesTable,
 	movieDirectorsTable,
-	movieServicesTable,
 	listsTable,
 	userEmailsTable,
 	usersTable,
+	watchedItemsTable,
 } from "@/db/schema";
 import { SUPPORTED_SERVICES } from "@/app/consts";
 
@@ -28,11 +28,11 @@ export const streamingServicesSeed = Object.values(SUPPORTED_SERVICES).map(
 export async function cleanupTables() {
 	await db.delete(loginAttemptsTable);
 	await db.delete(authTokensTable);
+	await db.delete(watchedItemsTable);
+	await db.delete(listItemMovieMatchTable);
 	await db.delete(listItemsTable);
-	await db.delete(listMoviesTable);
 	await db.delete(directorCacheTable);
 	await db.delete(movieDirectorsTable);
-	await db.delete(movieServicesTable);
 	await db.delete(directorsTable);
 	await db.delete(movieCacheTable);
 	await db.delete(moviesTable);
@@ -58,15 +58,9 @@ export async function resetSequences() {
 	await db.run(sql`DELETE FROM sqlite_sequence WHERE name = 'user_emails_table'`);
 	await db.run(sql`DELETE FROM sqlite_sequence WHERE name = 'login_attempts_table'`);
 	await db.run(
-		sql`DELETE FROM sqlite_sequence WHERE name = 'movie_services_table'`,
-	);
-	await db.run(
 		sql`DELETE FROM sqlite_sequence WHERE name = 'movie_directors_table'`,
 	);
 	await db.run(sql`DELETE FROM sqlite_sequence WHERE name = 'lists_table'`);
-	await db.run(
-		sql`DELETE FROM sqlite_sequence WHERE name = 'list_movies_table'`,
-	);
 	await db.run(
 		sql`DELETE FROM sqlite_sequence WHERE name = 'list_items_table'`,
 	);


### PR DESCRIPTION
## 変更内容

リストアイテムのテーブル構造を正規化。
UPDATEせずにINSERTだけで状態を更新できるよう変更した。

nullableだった映画マスタとの紐付けを別テーブルへ切り出し。
真偽値（0 or 1）で管理していた視聴ステータスを視聴済みテーブルへ切り出し。

リファクタリングとして不使用の古いテーブルを削除。