### PR TITLE
認証トークン種別ごとに個別のテーブルへ分離

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -130,19 +130,39 @@ export const watchedItemsTable = sqliteTable("watched_items_table", {
 	watchedAt: int("watched_at", { mode: "timestamp" }).notNull(),
 });
 
-export const authTokensTable = sqliteTable("auth_tokens_table", {
+export const loginCodesTable = sqliteTable("login_codes_table", {
 	token: text("token").notNull().unique(),
-	tokenType: text("token_type")
-		.$type<"session_token" | "temp_session_token" | "login_code">()
-		.notNull(),
 	email: text("email").notNull(),
 	userId: int("user_id").references(() => usersTable.id, {
 		onDelete: "cascade",
 	}),
-	deviceId: text("device_id"),
 	expiresAt: int("expires_at", { mode: "timestamp" }).notNull(),
 	createdAt: int("created_at", { mode: "timestamp" }).notNull(),
 });
+
+export const sessionTokensTable = sqliteTable("session_tokens_table", {
+	token: text("token").notNull().unique(),
+	email: text("email").notNull(),
+	userId: int("user_id")
+		.notNull()
+		.references(() => usersTable.id, {
+			onDelete: "cascade",
+		}),
+	deviceId: text("device_id").notNull(),
+	expiresAt: int("expires_at", { mode: "timestamp" }).notNull(),
+	createdAt: int("created_at", { mode: "timestamp" }).notNull(),
+});
+
+export const tempSessionTokensTable = sqliteTable(
+	"temp_session_tokens_table",
+	{
+		token: text("token").notNull().unique(),
+		email: text("email").notNull(),
+		deviceId: text("device_id").notNull(),
+		expiresAt: int("expires_at", { mode: "timestamp" }).notNull(),
+		createdAt: int("created_at", { mode: "timestamp" }).notNull(),
+	},
+);
 
 export const loginAttemptsTable = sqliteTable("login_attempts_table", {
 	id: int().primaryKey({ autoIncrement: true }),

--- a/features/auth/actions/login.test.ts
+++ b/features/auth/actions/login.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "@/db/client";
 import type { Tx } from "@/db/client";
 import {
-	authTokensTable,
 	loginAttemptsTable,
+	loginCodesTable,
+	sessionTokensTable,
+	tempSessionTokensTable,
 	userEmailsTable,
 	usersTable,
 } from "@/db/schema";
@@ -67,9 +69,8 @@ async function insertLoginCode({
 		.innerJoin(userEmailsTable, eq(userEmailsTable.userId, usersTable.id))
 		.where(eq(userEmailsTable.email, email));
 
-	await tx.insert(authTokensTable).values({
+	await tx.insert(loginCodesTable).values({
 		token,
-		tokenType: "login_code",
 		email,
 		userId: user?.id ?? null,
 		expiresAt,
@@ -145,25 +146,15 @@ describe("login", () => {
 
 		const [savedLoginCode] = await db
 			.select()
-			.from(authTokensTable)
-			.where(
-				and(
-					eq(authTokensTable.email, email),
-					eq(authTokensTable.tokenType, "login_code"),
-				),
-			);
+			.from(loginCodesTable)
+			.where(eq(loginCodesTable.email, email));
 
 		expect(savedLoginCode).toBeUndefined();
 
 		const [savedSessionToken] = await db
 			.select()
-			.from(authTokensTable)
-			.where(
-				and(
-					eq(authTokensTable.email, email),
-					eq(authTokensTable.tokenType, "session_token"),
-				),
-			);
+			.from(sessionTokensTable)
+			.where(eq(sessionTokensTable.email, email));
 
 		expect(savedSessionToken).toBeDefined();
 		if (!savedSessionToken) {
@@ -246,25 +237,15 @@ describe("login", () => {
 
 		const [savedLoginCode] = await db
 			.select()
-			.from(authTokensTable)
-			.where(
-				and(
-					eq(authTokensTable.email, newUserEmail),
-					eq(authTokensTable.tokenType, "login_code"),
-				),
-			);
+			.from(loginCodesTable)
+			.where(eq(loginCodesTable.email, newUserEmail));
 
 		expect(savedLoginCode).toBeUndefined();
 
 		const [tempToken] = await db
 			.select()
-			.from(authTokensTable)
-			.where(
-				and(
-					eq(authTokensTable.email, newUserEmail),
-					eq(authTokensTable.tokenType, "temp_session_token"),
-				),
-			);
+			.from(tempSessionTokensTable)
+			.where(eq(tempSessionTokensTable.email, newUserEmail));
 
 		expect(tempToken).toBeDefined();
 		if (!tempToken) {
@@ -272,7 +253,6 @@ describe("login", () => {
 		}
 
 		expect(tempToken.token).toBe(tempCookieValue);
-		expect(tempToken.userId).toBeNull();
 		expect(tempToken.deviceId).toBe(expectedDeviceId);
 		expect(tempToken.createdAt).toEqual(now);
 		expect(tempToken.expiresAt).toEqual(tempSessionTokenExpiresAt);

--- a/features/auth/actions/sendLoginCode.test.ts
+++ b/features/auth/actions/sendLoginCode.test.ts
@@ -1,9 +1,9 @@
 import { createHash } from "node:crypto";
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "@/db/client";
 import {
-	authTokensTable,
+	loginCodesTable,
 	loginAttemptsTable,
 	userEmailsTable,
 	usersTable,
@@ -108,7 +108,7 @@ describe("sendLoginCode", () => {
 		mockResendConstructor.mockClear();
 
 		await db.delete(loginAttemptsTable);
-		await db.delete(authTokensTable);
+		await db.delete(loginCodesTable);
 		await db.delete(userEmailsTable);
 		await db.delete(usersTable);
 	});
@@ -145,15 +145,14 @@ describe("sendLoginCode", () => {
 
 		const [savedToken] = await db
 			.select()
-			.from(authTokensTable)
-			.where(eq(authTokensTable.email, existingUserEmail));
+			.from(loginCodesTable)
+			.where(eq(loginCodesTable.email, existingUserEmail));
 
 		expect(savedToken).toBeDefined();
 		if (!savedToken) {
 			throw new Error("認証コードが保存されていません");
 		}
 
-		expect(savedToken.tokenType).toBe("login_code");
 		expect(savedToken.userId).toBe(existingUser.id);
 		expect(savedToken.createdAt).toEqual(now);
 		expect(savedToken.expiresAt).toEqual(
@@ -201,15 +200,14 @@ describe("sendLoginCode", () => {
 
 		const [savedToken] = await db
 			.select()
-			.from(authTokensTable)
-			.where(eq(authTokensTable.email, unregisteredUserEmail));
+			.from(loginCodesTable)
+			.where(eq(loginCodesTable.email, unregisteredUserEmail));
 
 		expect(savedToken).toBeDefined();
 		if (!savedToken) {
 			throw new Error("認証コードが保存されていません");
 		}
 
-		expect(savedToken.tokenType).toBe("login_code");
 		expect(savedToken.userId).toBeNull();
 		expect(savedToken.createdAt).toEqual(now);
 		expect(savedToken.expiresAt).toEqual(
@@ -238,9 +236,8 @@ describe("sendLoginCode", () => {
 		const oldLoginCode = "123456";
 		const oldExpiresAt = new Date(now.getTime() + 5 * 60 * 1000);
 
-		await db.insert(authTokensTable).values({
+		await db.insert(loginCodesTable).values({
 			token: hashLoginCode(oldLoginCode),
-			tokenType: "login_code",
 			email: existingUserEmail,
 			userId: existingUser.id,
 			expiresAt: oldExpiresAt,
@@ -251,13 +248,8 @@ describe("sendLoginCode", () => {
 
 		const savedTokens = await db
 			.select()
-			.from(authTokensTable)
-			.where(
-				and(
-					eq(authTokensTable.email, existingUserEmail),
-					eq(authTokensTable.tokenType, "login_code"),
-				),
-			);
+			.from(loginCodesTable)
+			.where(eq(loginCodesTable.email, existingUserEmail));
 
 		expect(savedTokens).toHaveLength(1);
 

--- a/features/auth/repositories/authTokenRepository.ts
+++ b/features/auth/repositories/authTokenRepository.ts
@@ -1,6 +1,10 @@
 import type { Tx } from "@/db/client";
 import { db } from "@/db/client";
-import { authTokensTable } from "@/db/schema";
+import {
+	loginCodesTable,
+	sessionTokensTable,
+	tempSessionTokensTable,
+} from "@/db/schema";
 import { and, eq, gt } from "drizzle-orm";
 
 export async function searchLoginCode({
@@ -14,12 +18,11 @@ export async function searchLoginCode({
 }) {
 	const [loginCode] = await tx
 		.select()
-		.from(authTokensTable)
+		.from(loginCodesTable)
 		.where(
 			and(
-				eq(authTokensTable.token, loginCodeHash),
-				eq(authTokensTable.tokenType, "login_code"),
-				gt(authTokensTable.expiresAt, now),
+				eq(loginCodesTable.token, loginCodeHash),
+				gt(loginCodesTable.expiresAt, now),
 			),
 		);
 
@@ -35,13 +38,8 @@ export async function deleteLoginCode({
 }) {
 	const executor = tx || db;
 	await executor
-		.delete(authTokensTable)
-		.where(
-			and(
-				eq(authTokensTable.email, email),
-				eq(authTokensTable.tokenType, "login_code"),
-			),
-		);
+		.delete(loginCodesTable)
+		.where(eq(loginCodesTable.email, email));
 }
 
 export async function insertLoginCode({
@@ -59,9 +57,8 @@ export async function insertLoginCode({
 	expiresAt: Date;
 	createdAt: Date;
 }) {
-	await tx.insert(authTokensTable).values({
+	await tx.insert(loginCodesTable).values({
 		token,
-		tokenType: "login_code",
 		email,
 		userId: userId ?? null,
 		expiresAt,
@@ -79,12 +76,11 @@ export async function deleteSessionToken({
 	deviceId: string;
 }) {
 	await tx
-		.delete(authTokensTable)
+		.delete(sessionTokensTable)
 		.where(
 			and(
-				eq(authTokensTable.tokenType, "session_token"),
-				eq(authTokensTable.userId, userId),
-				eq(authTokensTable.deviceId, deviceId),
+				eq(sessionTokensTable.userId, userId),
+				eq(sessionTokensTable.deviceId, deviceId),
 			),
 		);
 }
@@ -106,9 +102,8 @@ export async function insertSessionToken({
 	now: Date;
 	expiresAt: Date;
 }) {
-	await tx.insert(authTokensTable).values({
+	await tx.insert(sessionTokensTable).values({
 		token: sessionToken,
-		tokenType: "session_token",
 		deviceId,
 		email,
 		userId,
@@ -132,12 +127,10 @@ export async function insertTempToken({
 	deviceId: string;
 	createdAt: Date;
 }) {
-	await tx.insert(authTokensTable).values({
+	await tx.insert(tempSessionTokensTable).values({
 		token: tempToken,
-		tokenType: "temp_session_token",
 		deviceId,
 		email,
-		userId: null,
 		createdAt,
 		expiresAt,
 	});

--- a/features/auth/services/session.test.ts
+++ b/features/auth/services/session.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { db } from "@/db/client";
-import { authTokensTable, usersTable } from "@/db/schema";
+import { tempSessionTokensTable, usersTable } from "@/db/schema";
 import {
 	generateTempSessionToken,
 	verifyTempSessionToken,
@@ -10,7 +10,7 @@ describe("auth token verification", () => {
 	const now = new Date("2026-02-16T00:00:00.000Z");
 
 	beforeEach(async () => {
-		await db.delete(authTokensTable);
+		await db.delete(tempSessionTokensTable);
 		await db.delete(usersTable);
 	});
 
@@ -18,10 +18,10 @@ describe("auth token verification", () => {
 		const email = "verify-temp-session-token-test@example.com";
 		const tempToken = generateTempSessionToken();
 
-		await db.insert(authTokensTable).values({
+		await db.insert(tempSessionTokensTable).values({
 			token: tempToken,
-			tokenType: "temp_session_token",
 			email,
+			deviceId: "verify-temp-session-token-device-id",
 			expiresAt: new Date(now.getTime() + 10 * 60 * 1000),
 			createdAt: now,
 		});

--- a/features/auth/services/session.ts
+++ b/features/auth/services/session.ts
@@ -1,7 +1,7 @@
 import { SignJWT } from "jose";
 import crypto from "node:crypto";
 import { db } from "@/db/client";
-import { authTokensTable } from "@/db/schema";
+import { tempSessionTokensTable } from "@/db/schema";
 import { and, eq, gt } from "drizzle-orm";
 
 export async function verifyTempSessionToken({
@@ -20,14 +20,13 @@ export async function verifyTempSessionToken({
 	try {
 		const [record] = await db
 			.select({
-				email: authTokensTable.email,
+				email: tempSessionTokensTable.email,
 			})
-			.from(authTokensTable)
+			.from(tempSessionTokensTable)
 			.where(
 				and(
-					eq(authTokensTable.token, tempToken),
-					eq(authTokensTable.tokenType, "temp_session_token"),
-					gt(authTokensTable.expiresAt, now),
+					eq(tempSessionTokensTable.token, tempToken),
+					gt(tempSessionTokensTable.expiresAt, now),
 				),
 			);
 

--- a/features/auth/services/verifySessionTokenService.ts
+++ b/features/auth/services/verifySessionTokenService.ts
@@ -1,7 +1,7 @@
 import type { Result } from "@/features/shared/types/Result";
 import { jwtVerify } from "jose";
 import { db } from "@/db/client";
-import { authTokensTable } from "@/db/schema";
+import { sessionTokensTable } from "@/db/schema";
 import { and, eq, gt } from "drizzle-orm";
 import { getSecretKey } from "@/lib/jwt";
 
@@ -29,7 +29,7 @@ export async function verifySessionTokenService({
 			};
 		}
 
-		const { userId, email, deviceId, type } = payload;
+		const { userId, email, deviceId } = payload;
 
 		const isString = (propName: unknown): propName is string => {
 			return typeof propName === "string";
@@ -66,19 +66,18 @@ export async function verifySessionTokenService({
 
 		const [record] = await db
 			.select({
-				userId: authTokensTable.userId,
-				email: authTokensTable.email,
-				deviceId: authTokensTable.deviceId,
+				userId: sessionTokensTable.userId,
+				email: sessionTokensTable.email,
+				deviceId: sessionTokensTable.deviceId,
 			})
-			.from(authTokensTable)
+			.from(sessionTokensTable)
 			.where(
 				and(
-					eq(authTokensTable.token, sessionToken),
-					eq(authTokensTable.tokenType, type),
-					eq(authTokensTable.userId, parsedUserId),
-					eq(authTokensTable.email, email),
-					eq(authTokensTable.deviceId, deviceId),
-					gt(authTokensTable.expiresAt, now),
+					eq(sessionTokensTable.token, sessionToken),
+					eq(sessionTokensTable.userId, parsedUserId),
+					eq(sessionTokensTable.email, email),
+					eq(sessionTokensTable.deviceId, deviceId),
+					gt(sessionTokensTable.expiresAt, now),
 				),
 			);
 

--- a/features/list/actions/getCurrentUserMovieList.test.ts
+++ b/features/list/actions/getCurrentUserMovieList.test.ts
@@ -4,9 +4,9 @@ import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "@/db/client";
 import {
-	authTokensTable,
 	listItemsTable,
 	listsTable,
+	sessionTokensTable,
 	streamingServicesTable,
 	userEmailsTable,
 	usersTable,
@@ -94,9 +94,8 @@ async function loginAsUser({
 		deviceId: "test-device-id",
 	});
 
-	await db.insert(authTokensTable).values({
+	await db.insert(sessionTokensTable).values({
 		token: sessionToken,
-		tokenType: "session_token",
 		email,
 		userId,
 		deviceId: "test-device-id",
@@ -118,7 +117,7 @@ describe("getCurrentUserMovieList", () => {
 		mockCookies.mockClear();
 		mockSessionTokenStore.clear();
 
-		await db.delete(authTokensTable);
+		await db.delete(sessionTokensTable);
 		await db.delete(listItemsTable);
 		await db.delete(listsTable);
 		await db.delete(usersTable);

--- a/features/user/actions/registerUser.ts
+++ b/features/user/actions/registerUser.ts
@@ -3,15 +3,16 @@
 import crypto from "node:crypto";
 import { headers, cookies } from "next/headers";
 import { db } from "@/db/client";
-import { and, eq, inArray } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import {
 	usersTable,
 	userEmailsTable,
 	listsTable,
-	authTokensTable,
 	listItemMovieMatchTable,
 	listItemsTable,
+	sessionTokensTable,
 	streamingServicesTable,
+	tempSessionTokensTable,
 	watchedItemsTable,
 } from "@/db/schema";
 import type { Result } from "@/features/shared/types/Result";
@@ -233,13 +234,8 @@ export async function registerUser({
 
 			if (tempToken) {
 				await tx
-					.delete(authTokensTable)
-					.where(
-						and(
-							eq(authTokensTable.token, tempToken),
-							eq(authTokensTable.tokenType, "temp_session_token"),
-						),
-					);
+					.delete(tempSessionTokensTable)
+					.where(eq(tempSessionTokensTable.token, tempToken));
 			}
 
 			const sessionToken = await generateSessionToken({
@@ -249,9 +245,8 @@ export async function registerUser({
 			});
 			const expiresAt = addDays(now, 30);
 
-			await tx.insert(authTokensTable).values({
+			await tx.insert(sessionTokensTable).values({
 				token: sessionToken,
-				tokenType: "session_token",
 				deviceId,
 				email,
 				userId: newUser.id,

--- a/migrations/0026_jazzy_red_hulk.sql
+++ b/migrations/0026_jazzy_red_hulk.sql
@@ -1,0 +1,46 @@
+CREATE TABLE `login_codes_table` (
+	`token` text NOT NULL,
+	`email` text NOT NULL,
+	`user_id` integer,
+	`expires_at` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users_table`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `login_codes_table_token_unique` ON `login_codes_table` (`token`);--> statement-breakpoint
+INSERT INTO `login_codes_table` (`token`, `email`, `user_id`, `expires_at`, `created_at`)
+SELECT `token`, `email`, `user_id`, `expires_at`, `created_at`
+FROM `auth_tokens_table`
+WHERE `token_type` = 'login_code';--> statement-breakpoint
+CREATE TABLE `session_tokens_table` (
+	`token` text NOT NULL,
+	`email` text NOT NULL,
+	`user_id` integer NOT NULL,
+	`device_id` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users_table`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `session_tokens_table_token_unique` ON `session_tokens_table` (`token`);--> statement-breakpoint
+INSERT INTO `session_tokens_table` (`token`, `email`, `user_id`, `device_id`, `expires_at`, `created_at`)
+SELECT `token`, `email`, `user_id`, `device_id`, `expires_at`, `created_at`
+FROM `auth_tokens_table`
+WHERE `token_type` = 'session_token'
+	AND `user_id` IS NOT NULL
+	AND `device_id` IS NOT NULL;--> statement-breakpoint
+CREATE TABLE `temp_session_tokens_table` (
+	`token` text NOT NULL,
+	`email` text NOT NULL,
+	`device_id` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `temp_session_tokens_table_token_unique` ON `temp_session_tokens_table` (`token`);--> statement-breakpoint
+INSERT INTO `temp_session_tokens_table` (`token`, `email`, `device_id`, `expires_at`, `created_at`)
+SELECT `token`, `email`, `device_id`, `expires_at`, `created_at`
+FROM `auth_tokens_table`
+WHERE `token_type` = 'temp_session_token'
+	AND `device_id` IS NOT NULL;--> statement-breakpoint
+DROP TABLE `auth_tokens_table`;

--- a/migrations/meta/0026_snapshot.json
+++ b/migrations/meta/0026_snapshot.json
@@ -1,0 +1,881 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f317fd7b-69b2-4877-be96-800c0078a352",
+  "prevId": "15411c22-766a-4e3b-82f8-a5515e829f83",
+  "tables": {
+    "director_cache_table": {
+      "name": "director_cache_table",
+      "columns": {
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "director_cache_table_movieId_movies_table_id_fk": {
+          "name": "director_cache_table_movieId_movies_table_id_fk",
+          "tableFrom": "director_cache_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "directors_table": {
+      "name": "directors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_item_movie_match_table": {
+      "name": "list_item_movie_match_table",
+      "columns": {
+        "list_item_id": {
+          "name": "list_item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "list_item_movie_match_table_list_item_id_list_items_table_id_fk": {
+          "name": "list_item_movie_match_table_list_item_id_list_items_table_id_fk",
+          "tableFrom": "list_item_movie_match_table",
+          "tableTo": "list_items_table",
+          "columnsFrom": [
+            "list_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_item_movie_match_table_movie_id_movies_table_id_fk": {
+          "name": "list_item_movie_match_table_movie_id_movies_table_id_fk",
+          "tableFrom": "list_item_movie_match_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_items_table": {
+      "name": "list_items_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "listId": {
+          "name": "listId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "streamingServiceId": {
+          "name": "streamingServiceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watchUrl": {
+          "name": "watchUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "titleOnService": {
+          "name": "titleOnService",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "list_items_table_publicId_unique": {
+          "name": "list_items_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        },
+        "list_items_table_listId_watchUrl_unique": {
+          "name": "list_items_table_listId_watchUrl_unique",
+          "columns": [
+            "listId",
+            "watchUrl"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "list_items_table_listId_lists_table_id_fk": {
+          "name": "list_items_table_listId_lists_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "lists_table",
+          "columnsFrom": [
+            "listId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "list_items_table_streamingServiceId_streaming_services_table_id_fk": {
+          "name": "list_items_table_streamingServiceId_streaming_services_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "streaming_services_table",
+          "columnsFrom": [
+            "streamingServiceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lists_table": {
+      "name": "lists_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "lists_table_publicId_unique": {
+          "name": "lists_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        },
+        "lists_table_userId_unique": {
+          "name": "lists_table_userId_unique",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "lists_table_userId_users_table_id_fk": {
+          "name": "lists_table_userId_users_table_id_fk",
+          "tableFrom": "lists_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "login_attempts_table": {
+      "name": "login_attempts_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_type": {
+          "name": "attempt_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "login_codes_table": {
+      "name": "login_codes_table",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "login_codes_table_token_unique": {
+          "name": "login_codes_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "login_codes_table_user_id_users_table_id_fk": {
+          "name": "login_codes_table_user_id_users_table_id_fk",
+          "tableFrom": "login_codes_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_cache_table": {
+      "name": "movie_cache_table",
+      "columns": {
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movie_cache_table_movieId_movies_table_id_fk": {
+          "name": "movie_cache_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_cache_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_directors_table": {
+      "name": "movie_directors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "directorId": {
+          "name": "directorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "movie_directors_movie_id_director_id_unique": {
+          "name": "movie_directors_movie_id_director_id_unique",
+          "columns": [
+            "movieId",
+            "directorId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "movie_directors_table_movieId_movies_table_id_fk": {
+          "name": "movie_directors_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_directors_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movie_directors_table_directorId_directors_table_id_fk": {
+          "name": "movie_directors_table_directorId_directors_table_id_fk",
+          "tableFrom": "movie_directors_table",
+          "tableTo": "directors_table",
+          "columnsFrom": [
+            "directorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies_table": {
+      "name": "movies_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "externalDatabaseMovieId": {
+          "name": "externalDatabaseMovieId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backgroundImage": {
+          "name": "backgroundImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posterImage": {
+          "name": "posterImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runningMinutes": {
+          "name": "runningMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "releaseDate": {
+          "name": "releaseDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "movies_table_externalDatabaseMovieId_unique": {
+          "name": "movies_table_externalDatabaseMovieId_unique",
+          "columns": [
+            "externalDatabaseMovieId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_tokens_table": {
+      "name": "session_tokens_table",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_tokens_table_token_unique": {
+          "name": "session_tokens_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_tokens_table_user_id_users_table_id_fk": {
+          "name": "session_tokens_table_user_id_users_table_id_fk",
+          "tableFrom": "session_tokens_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "streaming_services_table": {
+      "name": "streaming_services_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "streaming_services_table_slug_unique": {
+          "name": "streaming_services_table_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "temp_session_tokens_table": {
+      "name": "temp_session_tokens_table",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "temp_session_tokens_table_token_unique": {
+          "name": "temp_session_tokens_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_emails_table": {
+      "name": "user_emails_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_emails_table_email_unique": {
+          "name": "user_emails_table_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_emails_table_user_id_users_table_id_fk": {
+          "name": "user_emails_table_user_id_users_table_id_fk",
+          "tableFrom": "user_emails_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users_table": {
+      "name": "users_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_table_publicId_unique": {
+          "name": "users_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watched_items_table": {
+      "name": "watched_items_table",
+      "columns": {
+        "list_item_id": {
+          "name": "list_item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watched_at": {
+          "name": "watched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watched_items_table_list_item_id_list_items_table_id_fk": {
+          "name": "watched_items_table_list_item_id_list_items_table_id_fk",
+          "tableFrom": "watched_items_table",
+          "tableTo": "list_items_table",
+          "columnsFrom": [
+            "list_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1773824600673,
       "tag": "0025_curved_makkari",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1773825646702,
+      "tag": "0026_jazzy_red_hulk",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -1,15 +1,17 @@
 import { db } from "@/db/client";
 import { sql } from "drizzle-orm";
 import {
-	authTokensTable,
 	directorCacheTable,
 	directorsTable,
 	listItemMovieMatchTable,
 	listItemsTable,
+	loginCodesTable,
 	loginAttemptsTable,
 	movieCacheTable,
 	moviesTable,
+	sessionTokensTable,
 	streamingServicesTable,
+	tempSessionTokensTable,
 	movieDirectorsTable,
 	listsTable,
 	userEmailsTable,
@@ -27,7 +29,9 @@ export const streamingServicesSeed = Object.values(SUPPORTED_SERVICES).map(
 
 export async function cleanupTables() {
 	await db.delete(loginAttemptsTable);
-	await db.delete(authTokensTable);
+	await db.delete(loginCodesTable);
+	await db.delete(tempSessionTokensTable);
+	await db.delete(sessionTokensTable);
 	await db.delete(watchedItemsTable);
 	await db.delete(listItemMovieMatchTable);
 	await db.delete(listItemsTable);


### PR DESCRIPTION
## 変更内容

単一テーブルで管理していたログインコード / セッショントークン / 仮セッショントークンを個別のテーブルで管理する。
マイグレーション適用時、旧テーブルに既存レコードがあれば種別ごとに新テーブルへ移行する。
