### PR TITLE
視聴ステータス/視聴日の扱いを修正

### DIFF
--- a/app/components/ListItem/Drawn/DrawnListItem.stories.tsx
+++ b/app/components/ListItem/Drawn/DrawnListItem.stories.tsx
@@ -9,7 +9,8 @@ const movieWithoutDetails: ListItem = {
 	serviceSlug: "unext",
 	serviceName: "U-NEXT",
 	createdAt: new Date(),
-	isWatched: false
+	isWatched: false,
+	watchedAt: null,
 };
 
 const movieWithDetails: ListItem = {
@@ -20,6 +21,7 @@ const movieWithDetails: ListItem = {
 	serviceName: "U-NEXT",
 	createdAt: new Date(),
 	isWatched: false,
+	watchedAt: null,
 	details: {
 		movieId: 1,
 		officialTitle: "トータル・リコール",

--- a/app/components/ListItem/Editing/EditingListItem.stories.tsx
+++ b/app/components/ListItem/Editing/EditingListItem.stories.tsx
@@ -10,6 +10,7 @@ const movieWithDetails: ListItem = {
 	serviceName: "U-NEXT",
 	createdAt: new Date(),
 	isWatched: false,
+	watchedAt: null,
 	details: {
 		movieId: 1,
 		officialTitle: "トータル・リコール",
@@ -94,6 +95,6 @@ export const StoreFailed: Story = {
 export const StoreFailedWithErrorMessage: Story = {
 	args: {
 		storeSuccess: false,
-		errorMessage: "映画の追加に失敗しました。"
+		errorMessage: "映画の追加に失敗しました。",
 	},
 };

--- a/app/components/ListItem/New/NewListItem.stories.tsx
+++ b/app/components/ListItem/New/NewListItem.stories.tsx
@@ -10,6 +10,7 @@ const movieWithoutDetails: ListItem = {
 	serviceName: "U-NEXT",
 	createdAt: new Date(),
 	isWatched: false,
+	watchedAt: null,
 };
 
 const movieWithDetails: ListItem = {
@@ -20,6 +21,7 @@ const movieWithDetails: ListItem = {
 	serviceName: "U-NEXT",
 	createdAt: new Date(),
 	isWatched: false,
+	watchedAt: null,
 	details: {
 		movieId: 1,
 		officialTitle: "トータル・リコール",

--- a/app/components/ListItem/Preview/PreviewListItem.stories.tsx
+++ b/app/components/ListItem/Preview/PreviewListItem.stories.tsx
@@ -10,6 +10,7 @@ const movieWithDetails: ListItem = {
 	serviceName: "U-NEXT",
 	createdAt: new Date(),
 	isWatched: false,
+	watchedAt: null,
 	details: {
 		movieId: 1,
 		officialTitle: "トータル・リコール",

--- a/app/components/ListItem/Watch/WatchListItem.stories.tsx
+++ b/app/components/ListItem/Watch/WatchListItem.stories.tsx
@@ -10,6 +10,7 @@ const movieWithDetails: ListItem = {
 	serviceName: "U-NEXT",
 	createdAt: new Date(),
 	isWatched: false,
+	watchedAt: null,
 	details: {
 		movieId: 1,
 		officialTitle: "トータル・リコール",

--- a/app/components/ListItem/index.tsx
+++ b/app/components/ListItem/index.tsx
@@ -67,12 +67,12 @@ export default function ListItemCard({
 
 	const handleSubmit = () => {
 		const newItem = selectedMovie ?? movie;
+
 		const itemToStore = hasListItemId(newItem)
 			? newItem
 			: {
 					...newItem,
 					listItemId: window.crypto.randomUUID(),
-					isWatched: false,
 				};
 
 		submit({ movie: itemToStore, publicListId });

--- a/features/list/actions/getCurrentUserMovieList.test.ts
+++ b/features/list/actions/getCurrentUserMovieList.test.ts
@@ -233,6 +233,7 @@ describe("getCurrentUserMovieList", () => {
 					serviceSlug: "hulu",
 					serviceName: "Hulu",
 					isWatched: true,
+					watchedAt: new Date("2026-03-11T00:00:00.000Z"),
 					createdAt: new Date("2026-03-11T00:00:00.000Z"),
 				},
 				{
@@ -242,6 +243,7 @@ describe("getCurrentUserMovieList", () => {
 					serviceSlug: "netflix",
 					serviceName: "Netflix",
 					isWatched: false,
+					watchedAt: null,
 					createdAt: new Date("2026-03-12T00:00:00.000Z"),
 				},
 			],

--- a/features/list/actions/getUserMovieList.test.ts
+++ b/features/list/actions/getUserMovieList.test.ts
@@ -142,6 +142,7 @@ describe("getUserMovieList", () => {
 					serviceSlug: "hulu",
 					serviceName: "Hulu",
 					isWatched: true,
+					watchedAt: new Date("2026-03-11T00:00:00.000Z"),
 					createdAt: new Date("2026-03-11T00:00:00.000Z"),
 				},
 				{
@@ -151,6 +152,7 @@ describe("getUserMovieList", () => {
 					serviceSlug: "netflix",
 					serviceName: "Netflix",
 					isWatched: false,
+					watchedAt: null,
 					createdAt: new Date("2026-03-12T00:00:00.000Z"),
 				},
 			],

--- a/features/list/actions/storeListItem.test.ts
+++ b/features/list/actions/storeListItem.test.ts
@@ -14,6 +14,7 @@ import {
 	streamingServicesTable,
 	userEmailsTable,
 	usersTable,
+	watchedItemsTable,
 } from "@/db/schema";
 import type { ListItem } from "../types/ListItem";
 import { TMDB_IMAGE_BASE_URL } from "@/app/consts";
@@ -150,6 +151,32 @@ async function assertListItemMovieMatchRecord({
 	expect(matchRecord.movieId).toBe(expectedMovieId);
 }
 
+async function assertWatchedItemRecord({
+	listItemId,
+	expectedWatchedAt,
+}: {
+	listItemId: number;
+	expectedWatchedAt: Date | null;
+}) {
+	const [watchedItemRecord] = await db
+		.select()
+		.from(watchedItemsTable)
+		.where(eq(watchedItemsTable.listItemId, listItemId));
+
+	if (expectedWatchedAt === null) {
+		expect(watchedItemRecord).toBeUndefined();
+		return;
+	}
+
+	expect(watchedItemRecord).toBeDefined();
+
+	if (!watchedItemRecord) {
+		throw Error("watched_items_table に視聴済みレコードが作成されていません");
+	}
+
+	expect(watchedItemRecord.watchedAt).toEqual(expectedWatchedAt);
+}
+
 async function assertMovieRecordFromTmdbDetails(movie: ListItem) {
 	if (!movie.details) {
 		throw Error("TMDBありケースのため movie.details が必要です");
@@ -230,7 +257,9 @@ async function assertDirectorCacheRecord(movieId: number) {
 	expect(directorCacheRecord).toBeDefined();
 
 	if (!directorCacheRecord) {
-		throw Error("director_cache_table にキャッシュレコードが作成されていません");
+		throw Error(
+			"director_cache_table にキャッシュレコードが作成されていません",
+		);
 	}
 
 	expect(directorCacheRecord.cachedAt).toBeInstanceOf(Date);
@@ -289,6 +318,7 @@ describe("storeMovie", () => {
 			serviceName: "Netflix",
 			createdAt: new Date(),
 			isWatched: false,
+			watchedAt: null,
 		};
 
 		const storeResult = await assertStoreMovieResult({
@@ -375,11 +405,12 @@ describe("storeMovie", () => {
 			serviceSlug: "prime-video",
 			serviceName: "Prime Video",
 			createdAt: new Date(),
+			watchedAt: null,
+			isWatched: false,
 			details: {
 				movieId: seededMovie.id,
 				...tmdbMovieDetails,
 			},
-			isWatched: false,
 		};
 
 		const storeResult = await assertStoreMovieResult({
@@ -414,6 +445,102 @@ describe("storeMovie", () => {
 			listItemId,
 			expectedMovieId: movieRecord.id,
 		});
+		await assertWatchedItemRecord({
+			listItemId,
+			expectedWatchedAt: null,
+		});
+	});
+
+	it("視聴済みの配信作品をリストへ新規登録できる", async () => {
+		const watchedAt = new Date("2026-03-20T00:00:00.000Z");
+		const movie: ListItem = {
+			listItemId: crypto.randomUUID(),
+			title: "ジュラシック・パーク",
+			url: "https://www.netflix.com/jp/title/60002360?s=i&trkid=258593161&vlang=ja&trg=more",
+			serviceSlug: "netflix",
+			serviceName: "Netflix",
+			createdAt: new Date("2026-03-19T00:00:00.000Z"),
+			isWatched: true,
+			watchedAt,
+		};
+
+		const storeResult = await assertStoreMovieResult({
+			publicListId: testListPublicId,
+			movie,
+			expectedTitle: movie.title,
+		});
+		expect(storeResult).not.toBeNull();
+		await assertMoviesTableHasNoRecords();
+		await assertDirectorsTableHasNoRecords();
+
+		const netflixStreamingServiceId = await getStreamingServiceIdBySlug(
+			movie.serviceSlug,
+		);
+
+		const listItemId = await assertListItemRecord({
+			testListId,
+			streamingServiceId: netflixStreamingServiceId,
+			movie,
+			expectedTitleOnService: movie.title,
+		});
+		if (!listItemId) {
+			throw Error("list_items_table へのレコード登録に失敗しています");
+		}
+
+		await assertListItemMovieMatchRecord({
+			listItemId,
+			expectedMovieId: null,
+		});
+		await assertWatchedItemRecord({
+			listItemId,
+			expectedWatchedAt: watchedAt,
+		});
+	});
+
+	it("未視聴の配信作品を視聴済みに変更できる", async () => {
+		const streamingServiceId = await getStreamingServiceIdBySlug("netflix");
+		const listItemPublicId = crypto.randomUUID();
+
+		const [seededListItem] = await db
+			.insert(listItemsTable)
+			.values({
+				publicId: listItemPublicId,
+				listId: testListId,
+				streamingServiceId,
+				watchUrl:
+					"https://www.netflix.com/jp/title/60002360?s=i&trkid=258593161&vlang=ja&trg=more",
+				titleOnService: "ジュラシック・パーク",
+				createdAt: new Date("2026-03-19T00:00:00.000Z"),
+			})
+			.returning({ id: listItemsTable.id });
+
+		await assertWatchedItemRecord({
+			listItemId: seededListItem.id,
+			expectedWatchedAt: null,
+		});
+
+		const watchedMovie: ListItem = {
+			listItemId: listItemPublicId,
+			title: "ジュラシック・パーク",
+			url: "https://www.netflix.com/jp/title/60002360?s=i&trkid=258593161&vlang=ja&trg=more",
+			serviceSlug: "netflix",
+			serviceName: "Netflix",
+			createdAt: new Date("2026-03-19T00:00:00.000Z"),
+			isWatched: true,
+			watchedAt: new Date("2026-03-20T00:00:00.000Z"),
+		};
+
+		const result = await storeListItem({
+			publicListId: testListPublicId,
+			movie: watchedMovie,
+			now: new Date("2026-03-21T00:00:00.000Z"),
+		});
+
+		expect(result.success).toBe(true);
+		await assertWatchedItemRecord({
+			listItemId: seededListItem.id,
+			expectedWatchedAt: watchedMovie.watchedAt,
+		});
 	});
 
 	it("同じサービスの同じ配信作品は登録できない", async () => {
@@ -425,6 +552,7 @@ describe("storeMovie", () => {
 			serviceName: "Netflix",
 			createdAt: new Date(),
 			isWatched: false,
+			watchedAt: null,
 		};
 		const secondMovie: ListItem = {
 			...firstMovie,
@@ -474,6 +602,7 @@ describe("storeMovie", () => {
 			serviceName: "Netflix",
 			createdAt: new Date(),
 			isWatched: false,
+			watchedAt: null,
 		};
 
 		const result = await storeListItem({
@@ -509,6 +638,7 @@ describe("storeMovie", () => {
 			serviceName: "Netflix",
 			createdAt: new Date(),
 			isWatched: false,
+			watchedAt: null,
 		};
 
 		const result = await storeListItem({

--- a/features/list/hooks/useExtractMovieInfo.ts
+++ b/features/list/hooks/useExtractMovieInfo.ts
@@ -99,6 +99,8 @@ export function useExtractMovieInfo() {
 			url,
 			serviceSlug: matcher.slug,
 			serviceName: matcher.name,
+			isWatched: false,
+			watchedAt: null,
 			createdAt: new Date(),
 		};
 	};
@@ -139,6 +141,8 @@ export function useExtractMovieInfo() {
 			url,
 			serviceSlug: matcherResult.slug,
 			serviceName: matcherResult.name,
+			isWatched: false,
+			watchedAt: null,
 			createdAt: new Date(),
 		};
 	};

--- a/features/list/repositories/server/listRepository.ts
+++ b/features/list/repositories/server/listRepository.ts
@@ -10,7 +10,11 @@ import {
 	streamingServicesTable,
 	watchedItemsTable,
 } from "@/db/schema";
-import type { ListItem } from "@/features/list/types/ListItem";
+import type {
+	ListItem,
+	WatchedState,
+	UnwatchedState,
+} from "@/features/list/types/ListItem";
 
 export type ListItemRow = {
 	listItemId: string;
@@ -63,23 +67,27 @@ export async function findStreamingServiceBySlug(
 	return streamingService;
 }
 
+type WatchStateInput = WatchedState | UnwatchedState;
+
+type UpsertListItemInput = {
+	listId: number;
+	listItemPublicId: string;
+	streamingServiceId: number;
+	movieId: number | null;
+	watchUrl: string;
+	titleOnService: string;
+} & WatchStateInput;
+
 export async function updateListItemByPublicIdAndListId({
 	listId,
 	listItemPublicId,
 	streamingServiceId,
 	movieId,
 	watchUrl,
-	watchStatus,
+	isWatched,
+	watchedAt,
 	titleOnService,
-}: {
-	listId: number;
-	listItemPublicId: string;
-	streamingServiceId: number;
-	movieId: number | null;
-	watchUrl: string;
-	watchStatus: 0 | 1;
-	titleOnService: string;
-}) {
+}: UpsertListItemInput) {
 	await db.transaction(async (tx) => {
 		const [updatedListItem] = await tx
 			.update(listItemsTable)
@@ -111,15 +119,18 @@ export async function updateListItemByPublicIdAndListId({
 			});
 		}
 
-		await tx
-			.delete(watchedItemsTable)
-			.where(eq(watchedItemsTable.listItemId, updatedListItem.id));
+		if (isWatched) {
+			const [existingWatchedItem] = await tx
+				.select({ listItemId: watchedItemsTable.listItemId })
+				.from(watchedItemsTable)
+				.where(eq(watchedItemsTable.listItemId, updatedListItem.id));
 
-		if (watchStatus === 1) {
-			await tx.insert(watchedItemsTable).values({
-				listItemId: updatedListItem.id,
-				watchedAt: new Date(),
-			});
+			if (!existingWatchedItem) {
+				await tx.insert(watchedItemsTable).values({
+					listItemId: updatedListItem.id,
+					watchedAt,
+				});
+			}
 		}
 	});
 }
@@ -130,19 +141,13 @@ export async function insertListItem({
 	streamingServiceId,
 	movieId,
 	watchUrl,
-	watchStatus,
+	isWatched,
+	watchedAt,
 	titleOnService,
 	createdAt,
 }: {
-	listId: number;
-	listItemPublicId: string;
-	streamingServiceId: number;
-	movieId: number | null;
-	watchUrl: string;
-	watchStatus: 0 | 1;
-	titleOnService: string;
 	createdAt: Date;
-}) {
+} & UpsertListItemInput) {
 	await db.transaction(async (tx) => {
 		const [insertedListItem] = await tx
 			.insert(listItemsTable)
@@ -163,10 +168,10 @@ export async function insertListItem({
 			});
 		}
 
-		if (watchStatus === 1) {
+		if (isWatched) {
 			await tx.insert(watchedItemsTable).values({
 				listItemId: insertedListItem.id,
-				watchedAt: createdAt,
+				watchedAt,
 			});
 		}
 	});
@@ -231,7 +236,10 @@ export async function findUserListItems(listPublicId: string, userId: number) {
 			eq(listItemMovieMatchTable.listItemId, listItemsTable.id),
 		)
 		.leftJoin(moviesTable, eq(listItemMovieMatchTable.movieId, moviesTable.id))
-		.leftJoin(watchedItemsTable, eq(watchedItemsTable.listItemId, listItemsTable.id))
+		.leftJoin(
+			watchedItemsTable,
+			eq(watchedItemsTable.listItemId, listItemsTable.id),
+		)
 		.where(
 			and(eq(listsTable.publicId, listPublicId), eq(listsTable.userId, userId)),
 		)

--- a/features/list/services/getUserListService.ts
+++ b/features/list/services/getUserListService.ts
@@ -60,6 +60,17 @@ const mapListItems = (
 	movieDirectors: Map<number, string[]>,
 ) => {
 	return rows.map((row) => {
+		const watchedState =
+			row.watchedAt === null
+				? {
+						isWatched: false as const,
+						watchedAt: null,
+					}
+				: {
+						isWatched: true as const,
+						watchedAt: row.watchedAt,
+					};
+
 		if (
 			row.movieId === null ||
 			row.officialTitle === null ||
@@ -77,7 +88,7 @@ const mapListItems = (
 				createdAt: row.createdAt,
 				serviceSlug: row.serviceSlug,
 				serviceName: row.serviceName,
-				isWatched: row.watchedAt !== null,
+				...watchedState,
 			};
 		}
 
@@ -88,7 +99,7 @@ const mapListItems = (
 			createdAt: row.createdAt,
 			serviceSlug: row.serviceSlug,
 			serviceName: row.serviceName,
-			isWatched: row.watchedAt !== null,
+			...watchedState,
 			details: {
 				movieId: row.movieId,
 				officialTitle: row.officialTitle,

--- a/features/list/services/storeListItemService.ts
+++ b/features/list/services/storeListItemService.ts
@@ -33,6 +33,15 @@ export async function storeListItemService({
 	try {
 		const titleOnService = movie.title;
 		const listItemPublicId = movie.listItemId;
+		const watchState = movie.isWatched
+			? {
+					isWatched: true as const,
+					watchedAt: movie.watchedAt,
+				}
+			: {
+					isWatched: false as const,
+					watchedAt: null,
+				};
 		const existingListItemId = await findListItemIdByPublicIdAndListId({
 			listItemPublicId: movie.listItemId,
 			listId,
@@ -46,7 +55,7 @@ export async function storeListItemService({
 				streamingServiceId: streamingService.id,
 				movieId: movie.details?.movieId ?? null,
 				watchUrl: movie.url,
-				watchStatus: movie.isWatched ? 1 : 0,
+				...watchState,
 				titleOnService,
 			});
 		} else {
@@ -56,10 +65,35 @@ export async function storeListItemService({
 				streamingServiceId: streamingService.id,
 				movieId: movie.details?.movieId ?? null,
 				watchUrl: movie.url,
-				watchStatus: movie.isWatched ? 1 : 0,
+				...watchState,
 				titleOnService,
 				createdAt: now,
 			});
+		}
+
+		const details = movie.details
+			? {
+					details: {
+						...movie.details,
+					},
+				}
+			: {};
+
+		if (movie.isWatched) {
+			return {
+				success: true,
+				data: {
+					listItemId: listItemPublicId,
+					title: titleOnService,
+					url: movie.url,
+					serviceSlug: streamingService.slug,
+					serviceName: streamingService.name,
+					isWatched: true,
+					watchedAt: movie.watchedAt,
+					createdAt,
+					...details,
+				},
+			};
 		}
 
 		return {
@@ -70,15 +104,10 @@ export async function storeListItemService({
 				url: movie.url,
 				serviceSlug: streamingService.slug,
 				serviceName: streamingService.name,
-				isWatched: movie.isWatched,
+				isWatched: false,
+				watchedAt: null,
 				createdAt,
-				...(movie.details
-					? {
-							details: {
-								...movie.details,
-							},
-						}
-					: {}),
+				...details,
 			},
 		};
 	} catch (error) {

--- a/features/list/types/ListItem.ts
+++ b/features/list/types/ListItem.ts
@@ -1,12 +1,10 @@
 import type { SupportedServiceSlug, SupportedServiceName } from "@/app/consts";
 
-export type ListItem = {
-	listItemId: string;
+type ListItemBase = {
 	title: string;
 	url: string;
 	serviceSlug: SupportedServiceSlug;
 	serviceName: SupportedServiceName;
-	isWatched: boolean;
 	createdAt: Date;
 	details?: {
 		movieId: number;
@@ -21,4 +19,20 @@ export type ListItem = {
 	};
 };
 
-export type DraftListItem = Omit<ListItem, "listItemId" | "isWatched">;
+export type WatchedState = {
+	isWatched: true;
+	watchedAt: Date;
+};
+
+export type UnwatchedState = {
+	isWatched: false;
+	watchedAt: null;
+};
+
+export type ListItem =
+	| (ListItemBase & { listItemId: string } & WatchedState)
+	| (ListItemBase & { listItemId: string } & UnwatchedState);
+
+export type DraftListItem =
+	| (ListItemBase & WatchedState)
+	| (ListItemBase & UnwatchedState);

--- a/features/movieDatabase/hooks/useExternalMovieDatabase.ts
+++ b/features/movieDatabase/hooks/useExternalMovieDatabase.ts
@@ -65,11 +65,8 @@ export const useExternalMovieDatabase = ({ movie }: Props) => {
 		fetchExternalMovieDatabaseAction,
 		isFetchExternalMovieDatabasePending,
 	] = useActionState<DraftListItem | ListItem | null, number | null>(
-		async (
-			_prev: DraftListItem | ListItem | null,
-			externalApiMovieId: number | null,
-		) => {
-			if (!externalApiMovieId) {
+		async (_prev, externalApiMovieId) => {
+			if (externalApiMovieId === null) {
 				return null;
 			}
 
@@ -94,30 +91,68 @@ export const useExternalMovieDatabase = ({ movie }: Props) => {
 				overview,
 			} = officialMovieInfo.data;
 
-			const directors = directorsInfo.data;
+			const details = {
+				movieId,
+				officialTitle: title,
+				backgroundImage: TMDB_IMAGE_BASE_URL + backdrop_path,
+				posterImage: TMDB_IMAGE_BASE_URL + poster_path,
+				runningMinutes: runtime,
+				releaseYear: new Date(release_date).getFullYear(),
+				director: directorsInfo.data,
+				externalDatabaseMovieId: externalApiMovieId,
+				overview,
+			};
+
+			if ("listItemId" in movie) {
+				if (movie.isWatched) {
+					return {
+						listItemId: movie.listItemId,
+						title: movie.title,
+						url: movie.url,
+						serviceSlug: movie.serviceSlug,
+						serviceName: movie.serviceName,
+						isWatched: true,
+						watchedAt: movie.watchedAt,
+						createdAt: movie.createdAt,
+						details,
+					};
+				}
+
+				return {
+					listItemId: movie.listItemId,
+					title: movie.title,
+					url: movie.url,
+					serviceSlug: movie.serviceSlug,
+					serviceName: movie.serviceName,
+					isWatched: false,
+					watchedAt: null,
+					createdAt: movie.createdAt,
+					details,
+				};
+			}
+
+			if (movie.isWatched) {
+				return {
+					title: movie.title,
+					url: movie.url,
+					serviceSlug: movie.serviceSlug,
+					serviceName: movie.serviceName,
+					isWatched: true,
+					watchedAt: movie.watchedAt,
+					createdAt: movie.createdAt,
+					details,
+				};
+			}
 
 			return {
 				title: movie.title,
 				url: movie.url,
 				serviceSlug: movie.serviceSlug,
 				serviceName: movie.serviceName,
+				isWatched: false,
+				watchedAt: null,
 				createdAt: movie.createdAt,
-				...("listItemId" in movie
-					? {
-							listItemId: movie.listItemId,
-						}
-					: {}),
-				details: {
-					movieId,
-					officialTitle: title,
-					backgroundImage: TMDB_IMAGE_BASE_URL + backdrop_path,
-					posterImage: TMDB_IMAGE_BASE_URL + poster_path,
-					runningMinutes: runtime,
-					releaseYear: new Date(release_date).getFullYear(),
-					director: directors,
-					externalDatabaseMovieId: externalApiMovieId,
-					overview,
-				},
+				details,
 			};
 		},
 		null,

--- a/features/shared/schemas/listItemSchema.ts
+++ b/features/shared/schemas/listItemSchema.ts
@@ -29,13 +29,23 @@ const listItemDetailsSchema = z.object({
 	overview: z.string().min(1),
 });
 
-export const listItemSchema = z.object({
+const listItemBaseSchema = z.object({
 	listItemId: z.uuid(),
 	title: z.string().min(1),
 	url: z.url(),
 	serviceSlug: supportedServiceSlugSchema,
 	serviceName: supportedServiceNameSchema,
-	isWatched: z.boolean(),
 	createdAt: z.coerce.date(),
 	details: listItemDetailsSchema.optional(),
 });
+
+export const listItemSchema = z.discriminatedUnion("isWatched", [
+	listItemBaseSchema.extend({
+		isWatched: z.literal(true),
+		watchedAt: z.coerce.date(),
+	}),
+	listItemBaseSchema.extend({
+		isWatched: z.literal(false),
+		watchedAt: z.null(),
+	}),
+]);

--- a/features/shared/store/index.ts
+++ b/features/shared/store/index.ts
@@ -24,18 +24,7 @@ export const localListAtom = atom(null, (get, set, payload: ListItem) => {
 	const current = get(risutopottoAtom);
 	const existing = current.list.items;
 
-	const next = [
-		...existing,
-		{
-			listItemId: payload.listItemId,
-			title: payload.title,
-			url: payload.url,
-			isWatched: payload.isWatched,
-			createdAt: payload.createdAt,
-			serviceName: payload.serviceName,
-			serviceSlug: payload.serviceSlug,
-		},
-	];
+	const next = [...existing, payload];
 	set(risutopottoAtom, {
 		list: {
 			listId: current.list.listId,

--- a/features/user/actions/registerUser.ts
+++ b/features/user/actions/registerUser.ts
@@ -161,7 +161,7 @@ export async function registerUser({
 				const seenWatchUrls = new Set<string>();
 				const listItems: Array<typeof listItemsTable.$inferInsert> = [];
 				const movieIdsByPublicId = new Map<string, number>();
-				const watchedItemPublicIds = new Set<string>();
+				const watchedAtByPublicId = new Map<string, Date>();
 
 				for (const item of validLocalListItems) {
 					if (seenWatchUrls.has(item.url)) {
@@ -188,7 +188,7 @@ export async function registerUser({
 					}
 
 					if (item.isWatched) {
-						watchedItemPublicIds.add(item.listItemId);
+						watchedAtByPublicId.set(item.listItemId, item.watchedAt);
 					}
 				}
 
@@ -216,11 +216,12 @@ export async function registerUser({
 					}
 
 					const watchedItems = insertedListItems.flatMap((item) => {
-						if (!watchedItemPublicIds.has(item.publicId)) {
+						const watchedAt = watchedAtByPublicId.get(item.publicId);
+						if (watchedAt === undefined) {
 							return [];
 						}
 
-						return [{ listItemId: item.id, watchedAt: item.createdAt }];
+						return [{ listItemId: item.id, watchedAt }];
 					});
 
 					if (watchedItems.length > 0) {


### PR DESCRIPTION
## 変更内容

ListItem型を修正。
視聴済みなら視聴日を持ち、未視聴なら視聴日を持たないことを型レベルで指定。

リスト登録時の初期値を未視聴に設定。

リスト登録処理のリポジトリ層へ、視聴済みだった場合の条件分岐を追加。
既存 or 新規のリストアイテムが視聴済みであれば`watched_items_table`へ視聴日を保存。