### PR TITLE
適用できてなかったマイグレーションをやりなおし

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { currentUserPublicListId } from "@/features/shared/actions/currentUserPublicListId";
+import { currentUserEmail } from "@/features/shared/actions/currentUserEmail";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import Menu from "@/components/Menu";
@@ -18,10 +19,13 @@ export default async function RootLayout({
 	const result = await currentUserPublicListId();
 	const publicListId = result.success ? result.data.publicListId : null;
 
+	const email = result.success ? await currentUserEmail() : null;
+	const emailValue = email?.success ? email.data.email : null;
+
 	return (
 		<html lang="ja">
 			<body className={`antialiased`}>
-				<Header isLoggedIn={result.success} />
+				<Header userEmail={emailValue} />
 
 				<main className="min-h-[calc(100dvh-var(--header-height))] pb-20">
 					{children}

--- a/components/Header/DrawerMenu/DrawerMenu.stories.tsx
+++ b/components/Header/DrawerMenu/DrawerMenu.stories.tsx
@@ -4,9 +4,6 @@ import DrawerMenu from "./index";
 
 const meta = {
 	component: DrawerMenu,
-	args: {
-		isLoggedIn: false,
-	},
 	parameters: {
 		layout: "centered",
 	},
@@ -18,10 +15,14 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const LoggedOut: Story = {};
+export const LoggedOut: Story = {
+	args: {
+		userEmail: null,
+	},
+};
 
 export const LoggedIn: Story = {
 	args: {
-		isLoggedIn: true,
+		userEmail: "risutopo@xxxxxxxxxx.com",
 	},
 };

--- a/components/Header/DrawerMenu/index.tsx
+++ b/components/Header/DrawerMenu/index.tsx
@@ -17,10 +17,10 @@ import PersonIcon from "../../ui/Icons/PersonIcon";
 import ArrowCircleRightIcon from "@/components/ui/Icons/ArrowCircleRightIcon";
 
 type Props = {
-	isLoggedIn: boolean;
+	userEmail: string | null;
 };
 
-export default function DrawerMenu({ isLoggedIn }: Props) {
+export default function DrawerMenu({ userEmail }: Props) {
 	const router = useRouter();
 	const [isPending, startTransition] = useTransition();
 
@@ -48,15 +48,15 @@ export default function DrawerMenu({ isLoggedIn }: Props) {
 
 				<div className="flex justify-center">
 					<div className="flex flex-col items-center gap-4 md:gap-6 p-4 w-full sm:max-w-[50dvw]">
-						{isLoggedIn ? (
+						{userEmail ? (
 							<>
 								<div className="p-4 w-full border border-background-light-1 rounded-xl">
-									<div className="flex flex-col gap-2 pb-4">
+									<div className="flex flex-col gap-2 pb-4 break-all">
 										<h3 className="text-lg font-bold text-foreground-dark-2">
-											メールアドレスの変更
+											ログインに使うメールアドレス
 										</h3>
-										<p className="text-sm text-foreground-dark-1">
-											ログインにつかうメールアドレスの確認・変更
+										<p className="text-foreground-dark-1">
+											{userEmail}
 										</p>
 									</div>
 									<DrawerClose asChild>

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -2,15 +2,15 @@ import Logo from "../Logo";
 import DrawerMenu from "./DrawerMenu";
 
 type Props = {
-	isLoggedIn: boolean;
+	userEmail: string | null;
 };
 
-export default function Header({ isLoggedIn }: Props) {
+export default async function Header({ userEmail }: Props) {
 	return (
 		<header className="relative h-(--header-height) flex justify-center items-center border-b border-background-light-1">
 			<div className="w-full h-full max-w-2xl flex justify-center">
 				<div className="w-full h-full flex items-center py-4 pl-4">
-					<DrawerMenu isLoggedIn={isLoggedIn} />
+					<DrawerMenu userEmail={userEmail} />
 				</div>
 
 				<div className="h-full aspect-square flex justify-center items-center absolute">

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -29,8 +29,8 @@ export const userEmailsTable = sqliteTable("user_emails_table", {
 		.references(() => usersTable.id, {
 			onDelete: "cascade",
 		}),
-	email: text("email").notNull().unique(),
-	emailHmac: text("email_hmac").unique(),
+	encryptedEmail: text("encrypted_email").notNull(),
+	emailHmac: text("email_hmac").notNull().unique(),
 });
 
 export const streamingServicesTable = sqliteTable("streaming_services_table", {

--- a/features/auth/actions/login.test.ts
+++ b/features/auth/actions/login.test.ts
@@ -98,7 +98,7 @@ describe("login", () => {
 		}).returning({ id: usersTable.id });
 		await db.insert(userEmailsTable).values({
 			userId: user.id,
-			email: encrypt(email),
+			encryptedEmail: encrypt(email),
 			emailHmac: computeHmac(email),
 		});
 

--- a/features/auth/actions/logout.test.ts
+++ b/features/auth/actions/logout.test.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "@/db/client";
+import { computeHmac, encrypt } from "@/features/shared/lib/encryption";
 import {
 	sessionTokensTable,
 	userEmailsTable,
@@ -64,7 +65,8 @@ describe("logout", () => {
 
 		await db.insert(userEmailsTable).values({
 			userId: user.id,
-			email,
+			encryptedEmail: encrypt(email),
+			emailHmac: computeHmac(email),
 		});
 
 		userId = user.id;

--- a/features/auth/actions/sendLoginCode.test.ts
+++ b/features/auth/actions/sendLoginCode.test.ts
@@ -91,7 +91,7 @@ describe("sendLoginCode", () => {
 
 		await db.insert(userEmailsTable).values({
 			userId: user.id,
-			email: encrypt(existingUserEmail),
+			encryptedEmail: encrypt(existingUserEmail),
 			emailHmac: computeHmac(existingUserEmail),
 		});
 

--- a/features/list/actions/getCurrentUserMovieList.test.ts
+++ b/features/list/actions/getCurrentUserMovieList.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@/db/schema";
 import { generateSessionToken } from "@/features/shared/lib/jwt";
 import { getCurrentUserMovieList } from "./getCurrentUserMovieList";
+import { computeHmac, encrypt } from "@/features/shared/lib/encryption";
 
 const { mockCookies, mockSessionTokenStore } = vi.hoisted(() => {
 	let sessionToken: string | undefined;
@@ -104,7 +105,8 @@ describe("getCurrentUserMovieList", () => {
 			.returning({ id: usersTable.id });
 		await db.insert(userEmailsTable).values({
 			userId: userA.id,
-			email: "get-current-user-movie-list-user-a@example.com",
+			encryptedEmail: encrypt("get-current-user-movie-list-user-a@example.com"),
+			emailHmac: computeHmac("get-current-user-movie-list-user-a@example.com"),
 		});
 
 		const [userB] = await db
@@ -115,7 +117,8 @@ describe("getCurrentUserMovieList", () => {
 			.returning({ id: usersTable.id });
 		await db.insert(userEmailsTable).values({
 			userId: userB.id,
-			email: "get-current-user-movie-list-user-b@example.com",
+			encryptedEmail: encrypt("get-current-user-movie-list-user-b@example.com"),
+			emailHmac: computeHmac("get-current-user-movie-list-user-b@example.com"),
 		});
 
 		userAId = userA.id;

--- a/features/list/actions/getUserMovieList.test.ts
+++ b/features/list/actions/getUserMovieList.test.ts
@@ -11,6 +11,7 @@ import {
 	watchedItemsTable,
 } from "@/db/schema";
 import { getUserMovieList } from "./getUserMovieList";
+import { computeHmac, encrypt } from "@/features/shared/lib/encryption";
 
 async function findStreamingServiceIdBySlug(slug: "netflix" | "hulu") {
 	const [streamingService] = await db
@@ -46,7 +47,8 @@ describe("getUserMovieList", () => {
 			.returning({ id: usersTable.id });
 		await db.insert(userEmailsTable).values({
 			userId: userA.id,
-			email: "get-user-movie-list-user-a@example.com",
+			encryptedEmail: encrypt("get-user-movie-list-user-a@example.com"),
+			emailHmac: computeHmac("get-user-movie-list-user-a@example.com"),
 		});
 
 		const [userB] = await db
@@ -57,7 +59,8 @@ describe("getUserMovieList", () => {
 			.returning({ id: usersTable.id });
 		await db.insert(userEmailsTable).values({
 			userId: userB.id,
-			email: "get-user-movie-list-user-b@example.com",
+			encryptedEmail: encrypt("get-user-movie-list-user-b@example.com"),
+			emailHmac: computeHmac("get-user-movie-list-user-b@example.com"),
 		});
 
 		userAId = userA.id;

--- a/features/list/actions/removeListItem.test.ts
+++ b/features/list/actions/removeListItem.test.ts
@@ -9,6 +9,7 @@ import {
 	userEmailsTable,
 	usersTable,
 } from "@/db/schema";
+import { computeHmac, encrypt } from "@/features/shared/lib/encryption";
 import { removeListItem } from "./removeListItem";
 
 describe("removeListItem", () => {
@@ -24,7 +25,8 @@ describe("removeListItem", () => {
 			.returning({ id: usersTable.id });
 		await db.insert(userEmailsTable).values({
 			userId: user.id,
-			email: "remove-list-item-test@risutopo.com",
+			encryptedEmail: encrypt("remove-list-item-test@risutopo.com"),
+			emailHmac: computeHmac("remove-list-item-test@risutopo.com"),
 		});
 
 		const [list] = await db

--- a/features/list/actions/storeListItem.test.ts
+++ b/features/list/actions/storeListItem.test.ts
@@ -18,6 +18,7 @@ import {
 } from "@/db/schema";
 import type { ListItem } from "../types/ListItem";
 import { TMDB_IMAGE_BASE_URL } from "@/app/consts";
+import { computeHmac, encrypt } from "@/features/shared/lib/encryption";
 import { storeListItem } from "./storeListItem";
 
 async function assertStoreMovieResult({
@@ -298,7 +299,8 @@ describe("storeMovie", () => {
 			.returning();
 		await db.insert(userEmailsTable).values({
 			userId: user.id,
-			email: "xxxxxxx@risutopo.com",
+			encryptedEmail: encrypt("xxxxxxx@risutopo.com"),
+			emailHmac: computeHmac("xxxxxxx@risutopo.com"),
 		});
 
 		const [list] = await db

--- a/features/shared/actions/currentUserEmail.ts
+++ b/features/shared/actions/currentUserEmail.ts
@@ -17,7 +17,7 @@ export const currentUserEmail = cache(
 		}
 
 		const [record] = await db
-			.select({ email: userEmailsTable.email })
+			.select({ encryptedEmail: userEmailsTable.encryptedEmail })
 			.from(userEmailsTable)
 			.where(eq(userEmailsTable.userId, userIdResult.data.userId));
 
@@ -33,7 +33,7 @@ export const currentUserEmail = cache(
 
 		return {
 			success: true,
-			data: { email: decrypt(record.email) },
+			data: { email: decrypt(record.encryptedEmail) },
 		};
 	},
 );

--- a/features/shared/lib/encryption.ts
+++ b/features/shared/lib/encryption.ts
@@ -12,7 +12,6 @@ function getHmacSecret(): Buffer {
 	return Buffer.from(secret, "hex");
 }
 
-// iv(12B) + authTag(16B) + 暗号文 をBase64で保存
 export function encrypt(plaintext: string): string {
 	const iv = crypto.randomBytes(12);
 	const cipher = crypto.createCipheriv("aes-256-gcm", getKey(), iv);
@@ -34,7 +33,6 @@ export function decrypt(ciphertext: string): string {
 	return decipher.update(encrypted) + decipher.final("utf8");
 }
 
-// 検索用：同じ入力から常に同じ値を生成する決定的ハッシュ
 export function computeHmac(value: string): string {
 	return crypto
 		.createHmac("sha256", getHmacSecret())

--- a/features/user/actions/deleteUser.test.ts
+++ b/features/user/actions/deleteUser.test.ts
@@ -72,7 +72,7 @@ describe("deleteUser", () => {
 
 		await db.insert(userEmailsTable).values({
 			userId: user.id,
-			email: encrypt(email),
+			encryptedEmail: encrypt(email),
 			emailHmac: computeHmac(email),
 		});
 

--- a/features/user/repositories/userEmailRepository.ts
+++ b/features/user/repositories/userEmailRepository.ts
@@ -24,7 +24,7 @@ export async function replaceUserEmail({
 	await tx.delete(userEmailsTable).where(eq(userEmailsTable.userId, userId));
 	await tx.insert(userEmailsTable).values({
 		userId,
-		email: encrypt(email),
+		encryptedEmail: encrypt(email),
 		emailHmac: computeHmac(email),
 	});
 }

--- a/features/user/repositories/userRepository.ts
+++ b/features/user/repositories/userRepository.ts
@@ -12,7 +12,7 @@ export async function getUserByEmailHmac(tx: Tx, emailHmac: string) {
 		.select({
 			id: usersTable.id,
 			publicId: usersTable.publicId,
-			email: userEmailsTable.email,
+			encryptedEmail: userEmailsTable.encryptedEmail,
 		})
 		.from(usersTable)
 		.innerJoin(userEmailsTable, eq(userEmailsTable.userId, usersTable.id))
@@ -22,7 +22,7 @@ export async function getUserByEmailHmac(tx: Tx, emailHmac: string) {
 	return {
 		id: user.id,
 		publicId: user.publicId,
-		email: decrypt(user.email),
+		email: decrypt(user.encryptedEmail),
 	};
 }
 

--- a/migrations/0034_encrypt_user_data.sql
+++ b/migrations/0034_encrypt_user_data.sql
@@ -1,9 +1,10 @@
-ALTER TABLE `users_table` ADD `public_id_hmac` text;--> statement-breakpoint
-CREATE UNIQUE INDEX `users_table_public_id_hmac_unique` ON `users_table` (`public_id_hmac`);--> statement-breakpoint
+DELETE FROM `login_attempts_table`;--> statement-breakpoint
+DELETE FROM `temp_session_tokens_table`;--> statement-breakpoint
+DELETE FROM `login_codes_table`;--> statement-breakpoint
+DELETE FROM `users_table`;--> statement-breakpoint
 ALTER TABLE `user_emails_table` ADD `email_hmac` text;--> statement-breakpoint
 CREATE UNIQUE INDEX `user_emails_table_email_hmac_unique` ON `user_emails_table` (`email_hmac`);--> statement-breakpoint
 ALTER TABLE `login_codes_table` RENAME COLUMN `email` TO `email_hmac`;--> statement-breakpoint
 ALTER TABLE `login_codes_table` ADD `encrypted_email` text NOT NULL DEFAULT '';--> statement-breakpoint
 ALTER TABLE `temp_session_tokens_table` RENAME COLUMN `email` TO `email_hmac`;--> statement-breakpoint
 ALTER TABLE `login_attempts_table` RENAME COLUMN `email` TO `email_hmac`;--> statement-breakpoint
-ALTER TABLE `deleted_users_table` RENAME COLUMN `public_id` TO `public_id_hmac`;

--- a/migrations/0035_add_encrypted_email_to_temp_tokens.sql
+++ b/migrations/0035_add_encrypted_email_to_temp_tokens.sql
@@ -1,1 +1,0 @@
-ALTER TABLE `temp_session_tokens_table` ADD `encrypted_email` text NOT NULL DEFAULT '';

--- a/migrations/0035_youthful_siren.sql
+++ b/migrations/0035_youthful_siren.sql
@@ -1,0 +1,6 @@
+DELETE FROM `login_attempts_table`;--> statement-breakpoint
+DELETE FROM `temp_session_tokens_table`;--> statement-breakpoint
+ALTER TABLE `login_attempts_table` ADD `ip_address_hmac` text NOT NULL;--> statement-breakpoint
+ALTER TABLE `login_attempts_table` DROP COLUMN `ip_address`;--> statement-breakpoint
+ALTER TABLE `login_attempts_table` DROP COLUMN `email`;--> statement-breakpoint
+ALTER TABLE `temp_session_tokens_table` ADD `encrypted_email` text NOT NULL;

--- a/migrations/0036_fixed_fantastic_four.sql
+++ b/migrations/0036_fixed_fantastic_four.sql
@@ -1,0 +1,14 @@
+DELETE FROM `user_emails_table`;--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_user_emails_table` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` integer NOT NULL,
+	`encrypted_email` text NOT NULL,
+	`email_hmac` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users_table`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+DROP TABLE `user_emails_table`;--> statement-breakpoint
+ALTER TABLE `__new_user_emails_table` RENAME TO `user_emails_table`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `user_emails_table_email_hmac_unique` ON `user_emails_table` (`email_hmac`);

--- a/migrations/0036_revert_public_id_protect_ip.sql
+++ b/migrations/0036_revert_public_id_protect_ip.sql
@@ -1,9 +1,0 @@
-DROP INDEX IF EXISTS `users_table_public_id_hmac_unique`;
---> statement-breakpoint
-ALTER TABLE `users_table` DROP COLUMN `public_id_hmac`;
---> statement-breakpoint
-ALTER TABLE `deleted_users_table` RENAME COLUMN `public_id_hmac` TO `public_id`;
---> statement-breakpoint
-ALTER TABLE `login_attempts_table` RENAME COLUMN `ip_address` TO `ip_address_hmac`;
---> statement-breakpoint
-ALTER TABLE `login_attempts_table` DROP COLUMN `email_hmac`;

--- a/migrations/0037_fix_login_tables.sql
+++ b/migrations/0037_fix_login_tables.sql
@@ -1,0 +1,29 @@
+DELETE FROM `login_codes_table`;--> statement-breakpoint
+DELETE FROM `temp_session_tokens_table`;--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_login_codes_table` (
+	`token` text NOT NULL,
+	`email_hmac` text NOT NULL,
+	`encrypted_email` text NOT NULL,
+	`user_id` integer REFERENCES `users_table`(`id`) ON UPDATE no action ON DELETE cascade,
+	`expires_at` integer NOT NULL,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+DROP TABLE `login_codes_table`;--> statement-breakpoint
+ALTER TABLE `__new_login_codes_table` RENAME TO `login_codes_table`;--> statement-breakpoint
+CREATE TABLE `__new_temp_session_tokens_table` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`token` text NOT NULL,
+	`email_hmac` text NOT NULL,
+	`encrypted_email` text NOT NULL,
+	`device_id` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+DROP TABLE `temp_session_tokens_table`;--> statement-breakpoint
+ALTER TABLE `__new_temp_session_tokens_table` RENAME TO `temp_session_tokens_table`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `login_codes_table_token_unique` ON `login_codes_table` (`token`);--> statement-breakpoint
+CREATE UNIQUE INDEX `temp_session_tokens_table_token_unique` ON `temp_session_tokens_table` (`token`);

--- a/migrations/meta/0035_snapshot.json
+++ b/migrations/meta/0035_snapshot.json
@@ -1,0 +1,1007 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "646c4fb2-197d-42ae-9837-565ed7540ba4",
+  "prevId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "tables": {
+    "deleted_users_table": {
+      "name": "deleted_users_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "director_cache_table": {
+      "name": "director_cache_table",
+      "columns": {
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "director_cache_table_movieId_movies_table_id_fk": {
+          "name": "director_cache_table_movieId_movies_table_id_fk",
+          "tableFrom": "director_cache_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "directors_table": {
+      "name": "directors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_item_movie_match_table": {
+      "name": "list_item_movie_match_table",
+      "columns": {
+        "list_item_id": {
+          "name": "list_item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "list_item_movie_match_table_list_item_id_list_items_table_id_fk": {
+          "name": "list_item_movie_match_table_list_item_id_list_items_table_id_fk",
+          "tableFrom": "list_item_movie_match_table",
+          "tableTo": "list_items_table",
+          "columnsFrom": [
+            "list_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_item_movie_match_table_movie_id_movies_table_id_fk": {
+          "name": "list_item_movie_match_table_movie_id_movies_table_id_fk",
+          "tableFrom": "list_item_movie_match_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_items_table": {
+      "name": "list_items_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "listId": {
+          "name": "listId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "streamingServiceId": {
+          "name": "streamingServiceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watchUrl": {
+          "name": "watchUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "titleOnService": {
+          "name": "titleOnService",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "list_items_table_publicId_unique": {
+          "name": "list_items_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        },
+        "list_items_table_listId_watchUrl_unique": {
+          "name": "list_items_table_listId_watchUrl_unique",
+          "columns": [
+            "listId",
+            "watchUrl"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "list_items_table_listId_lists_table_id_fk": {
+          "name": "list_items_table_listId_lists_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "lists_table",
+          "columnsFrom": [
+            "listId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_items_table_streamingServiceId_streaming_services_table_id_fk": {
+          "name": "list_items_table_streamingServiceId_streaming_services_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "streaming_services_table",
+          "columnsFrom": [
+            "streamingServiceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lists_table": {
+      "name": "lists_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "lists_table_publicId_unique": {
+          "name": "lists_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        },
+        "lists_table_userId_unique": {
+          "name": "lists_table_userId_unique",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "lists_table_userId_users_table_id_fk": {
+          "name": "lists_table_userId_users_table_id_fk",
+          "tableFrom": "lists_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "login_attempts_table": {
+      "name": "login_attempts_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ip_address_hmac": {
+          "name": "ip_address_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt_type": {
+          "name": "attempt_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "login_codes_table": {
+      "name": "login_codes_table",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_hmac": {
+          "name": "email_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_email": {
+          "name": "encrypted_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "login_codes_table_token_unique": {
+          "name": "login_codes_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "login_codes_table_user_id_users_table_id_fk": {
+          "name": "login_codes_table_user_id_users_table_id_fk",
+          "tableFrom": "login_codes_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_cache_table": {
+      "name": "movie_cache_table",
+      "columns": {
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movie_cache_table_movieId_movies_table_id_fk": {
+          "name": "movie_cache_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_cache_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_directors_table": {
+      "name": "movie_directors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "directorId": {
+          "name": "directorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "movie_directors_movie_id_director_id_unique": {
+          "name": "movie_directors_movie_id_director_id_unique",
+          "columns": [
+            "movieId",
+            "directorId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "movie_directors_table_movieId_movies_table_id_fk": {
+          "name": "movie_directors_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_directors_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movie_directors_table_directorId_directors_table_id_fk": {
+          "name": "movie_directors_table_directorId_directors_table_id_fk",
+          "tableFrom": "movie_directors_table",
+          "tableTo": "directors_table",
+          "columnsFrom": [
+            "directorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies_table": {
+      "name": "movies_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "externalDatabaseMovieId": {
+          "name": "externalDatabaseMovieId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backgroundImage": {
+          "name": "backgroundImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posterImage": {
+          "name": "posterImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runningMinutes": {
+          "name": "runningMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "releaseDate": {
+          "name": "releaseDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "movies_table_externalDatabaseMovieId_unique": {
+          "name": "movies_table_externalDatabaseMovieId_unique",
+          "columns": [
+            "externalDatabaseMovieId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reauth_tokens_table": {
+      "name": "reauth_tokens_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reauth_tokens_table_token_unique": {
+          "name": "reauth_tokens_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "reauth_tokens_table_user_id_users_table_id_fk": {
+          "name": "reauth_tokens_table_user_id_users_table_id_fk",
+          "tableFrom": "reauth_tokens_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_tokens_table": {
+      "name": "session_tokens_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_tokens_table_token_unique": {
+          "name": "session_tokens_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_tokens_table_user_id_users_table_id_fk": {
+          "name": "session_tokens_table_user_id_users_table_id_fk",
+          "tableFrom": "session_tokens_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "streaming_services_table": {
+      "name": "streaming_services_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "streaming_services_table_slug_unique": {
+          "name": "streaming_services_table_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "temp_session_tokens_table": {
+      "name": "temp_session_tokens_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_hmac": {
+          "name": "email_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_email": {
+          "name": "encrypted_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "temp_session_tokens_table_token_unique": {
+          "name": "temp_session_tokens_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_emails_table": {
+      "name": "user_emails_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_hmac": {
+          "name": "email_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_emails_table_email_unique": {
+          "name": "user_emails_table_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_emails_table_email_hmac_unique": {
+          "name": "user_emails_table_email_hmac_unique",
+          "columns": [
+            "email_hmac"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_emails_table_user_id_users_table_id_fk": {
+          "name": "user_emails_table_user_id_users_table_id_fk",
+          "tableFrom": "user_emails_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users_table": {
+      "name": "users_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_table_publicId_unique": {
+          "name": "users_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watched_items_table": {
+      "name": "watched_items_table",
+      "columns": {
+        "list_item_id": {
+          "name": "list_item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watched_at": {
+          "name": "watched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watched_items_table_list_item_id_list_items_table_id_fk": {
+          "name": "watched_items_table_list_item_id_list_items_table_id_fk",
+          "tableFrom": "watched_items_table",
+          "tableTo": "list_items_table",
+          "columnsFrom": [
+            "list_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/0036_snapshot.json
+++ b/migrations/meta/0036_snapshot.json
@@ -1,0 +1,1000 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "66a2364d-eca6-4777-8b3a-b75dbf5fb73b",
+  "prevId": "646c4fb2-197d-42ae-9837-565ed7540ba4",
+  "tables": {
+    "deleted_users_table": {
+      "name": "deleted_users_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "director_cache_table": {
+      "name": "director_cache_table",
+      "columns": {
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "director_cache_table_movieId_movies_table_id_fk": {
+          "name": "director_cache_table_movieId_movies_table_id_fk",
+          "tableFrom": "director_cache_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "directors_table": {
+      "name": "directors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_item_movie_match_table": {
+      "name": "list_item_movie_match_table",
+      "columns": {
+        "list_item_id": {
+          "name": "list_item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "list_item_movie_match_table_list_item_id_list_items_table_id_fk": {
+          "name": "list_item_movie_match_table_list_item_id_list_items_table_id_fk",
+          "tableFrom": "list_item_movie_match_table",
+          "tableTo": "list_items_table",
+          "columnsFrom": [
+            "list_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_item_movie_match_table_movie_id_movies_table_id_fk": {
+          "name": "list_item_movie_match_table_movie_id_movies_table_id_fk",
+          "tableFrom": "list_item_movie_match_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_items_table": {
+      "name": "list_items_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "listId": {
+          "name": "listId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "streamingServiceId": {
+          "name": "streamingServiceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watchUrl": {
+          "name": "watchUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "titleOnService": {
+          "name": "titleOnService",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "list_items_table_publicId_unique": {
+          "name": "list_items_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        },
+        "list_items_table_listId_watchUrl_unique": {
+          "name": "list_items_table_listId_watchUrl_unique",
+          "columns": [
+            "listId",
+            "watchUrl"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "list_items_table_listId_lists_table_id_fk": {
+          "name": "list_items_table_listId_lists_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "lists_table",
+          "columnsFrom": [
+            "listId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_items_table_streamingServiceId_streaming_services_table_id_fk": {
+          "name": "list_items_table_streamingServiceId_streaming_services_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "streaming_services_table",
+          "columnsFrom": [
+            "streamingServiceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lists_table": {
+      "name": "lists_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "lists_table_publicId_unique": {
+          "name": "lists_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        },
+        "lists_table_userId_unique": {
+          "name": "lists_table_userId_unique",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "lists_table_userId_users_table_id_fk": {
+          "name": "lists_table_userId_users_table_id_fk",
+          "tableFrom": "lists_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "login_attempts_table": {
+      "name": "login_attempts_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ip_address_hmac": {
+          "name": "ip_address_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt_type": {
+          "name": "attempt_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "login_codes_table": {
+      "name": "login_codes_table",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_hmac": {
+          "name": "email_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_email": {
+          "name": "encrypted_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "login_codes_table_token_unique": {
+          "name": "login_codes_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "login_codes_table_user_id_users_table_id_fk": {
+          "name": "login_codes_table_user_id_users_table_id_fk",
+          "tableFrom": "login_codes_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_cache_table": {
+      "name": "movie_cache_table",
+      "columns": {
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movie_cache_table_movieId_movies_table_id_fk": {
+          "name": "movie_cache_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_cache_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_directors_table": {
+      "name": "movie_directors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "directorId": {
+          "name": "directorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "movie_directors_movie_id_director_id_unique": {
+          "name": "movie_directors_movie_id_director_id_unique",
+          "columns": [
+            "movieId",
+            "directorId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "movie_directors_table_movieId_movies_table_id_fk": {
+          "name": "movie_directors_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_directors_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movie_directors_table_directorId_directors_table_id_fk": {
+          "name": "movie_directors_table_directorId_directors_table_id_fk",
+          "tableFrom": "movie_directors_table",
+          "tableTo": "directors_table",
+          "columnsFrom": [
+            "directorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies_table": {
+      "name": "movies_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "externalDatabaseMovieId": {
+          "name": "externalDatabaseMovieId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backgroundImage": {
+          "name": "backgroundImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posterImage": {
+          "name": "posterImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runningMinutes": {
+          "name": "runningMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "releaseDate": {
+          "name": "releaseDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "movies_table_externalDatabaseMovieId_unique": {
+          "name": "movies_table_externalDatabaseMovieId_unique",
+          "columns": [
+            "externalDatabaseMovieId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reauth_tokens_table": {
+      "name": "reauth_tokens_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reauth_tokens_table_token_unique": {
+          "name": "reauth_tokens_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "reauth_tokens_table_user_id_users_table_id_fk": {
+          "name": "reauth_tokens_table_user_id_users_table_id_fk",
+          "tableFrom": "reauth_tokens_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_tokens_table": {
+      "name": "session_tokens_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_tokens_table_token_unique": {
+          "name": "session_tokens_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_tokens_table_user_id_users_table_id_fk": {
+          "name": "session_tokens_table_user_id_users_table_id_fk",
+          "tableFrom": "session_tokens_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "streaming_services_table": {
+      "name": "streaming_services_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "streaming_services_table_slug_unique": {
+          "name": "streaming_services_table_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "temp_session_tokens_table": {
+      "name": "temp_session_tokens_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_hmac": {
+          "name": "email_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_email": {
+          "name": "encrypted_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "temp_session_tokens_table_token_unique": {
+          "name": "temp_session_tokens_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_emails_table": {
+      "name": "user_emails_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_email": {
+          "name": "encrypted_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_hmac": {
+          "name": "email_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_emails_table_email_hmac_unique": {
+          "name": "user_emails_table_email_hmac_unique",
+          "columns": [
+            "email_hmac"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_emails_table_user_id_users_table_id_fk": {
+          "name": "user_emails_table_user_id_users_table_id_fk",
+          "tableFrom": "user_emails_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users_table": {
+      "name": "users_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_table_publicId_unique": {
+          "name": "users_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watched_items_table": {
+      "name": "watched_items_table",
+      "columns": {
+        "list_item_id": {
+          "name": "list_item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watched_at": {
+          "name": "watched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watched_items_table_list_item_id_list_items_table_id_fk": {
+          "name": "watched_items_table_list_item_id_list_items_table_id_fk",
+          "tableFrom": "watched_items_table",
+          "tableTo": "list_items_table",
+          "columnsFrom": [
+            "list_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/0037_snapshot.json
+++ b/migrations/meta/0037_snapshot.json
@@ -1,0 +1,1000 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "66a2364d-eca6-4777-8b3a-b75dbf5fb73b",
+  "prevId": "646c4fb2-197d-42ae-9837-565ed7540ba4",
+  "tables": {
+    "deleted_users_table": {
+      "name": "deleted_users_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "director_cache_table": {
+      "name": "director_cache_table",
+      "columns": {
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "director_cache_table_movieId_movies_table_id_fk": {
+          "name": "director_cache_table_movieId_movies_table_id_fk",
+          "tableFrom": "director_cache_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "directors_table": {
+      "name": "directors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_item_movie_match_table": {
+      "name": "list_item_movie_match_table",
+      "columns": {
+        "list_item_id": {
+          "name": "list_item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "list_item_movie_match_table_list_item_id_list_items_table_id_fk": {
+          "name": "list_item_movie_match_table_list_item_id_list_items_table_id_fk",
+          "tableFrom": "list_item_movie_match_table",
+          "tableTo": "list_items_table",
+          "columnsFrom": [
+            "list_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_item_movie_match_table_movie_id_movies_table_id_fk": {
+          "name": "list_item_movie_match_table_movie_id_movies_table_id_fk",
+          "tableFrom": "list_item_movie_match_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_items_table": {
+      "name": "list_items_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "listId": {
+          "name": "listId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "streamingServiceId": {
+          "name": "streamingServiceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watchUrl": {
+          "name": "watchUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "titleOnService": {
+          "name": "titleOnService",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "list_items_table_publicId_unique": {
+          "name": "list_items_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        },
+        "list_items_table_listId_watchUrl_unique": {
+          "name": "list_items_table_listId_watchUrl_unique",
+          "columns": [
+            "listId",
+            "watchUrl"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "list_items_table_listId_lists_table_id_fk": {
+          "name": "list_items_table_listId_lists_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "lists_table",
+          "columnsFrom": [
+            "listId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_items_table_streamingServiceId_streaming_services_table_id_fk": {
+          "name": "list_items_table_streamingServiceId_streaming_services_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "streaming_services_table",
+          "columnsFrom": [
+            "streamingServiceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lists_table": {
+      "name": "lists_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "lists_table_publicId_unique": {
+          "name": "lists_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        },
+        "lists_table_userId_unique": {
+          "name": "lists_table_userId_unique",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "lists_table_userId_users_table_id_fk": {
+          "name": "lists_table_userId_users_table_id_fk",
+          "tableFrom": "lists_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "login_attempts_table": {
+      "name": "login_attempts_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ip_address_hmac": {
+          "name": "ip_address_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt_type": {
+          "name": "attempt_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "login_codes_table": {
+      "name": "login_codes_table",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_hmac": {
+          "name": "email_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_email": {
+          "name": "encrypted_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "login_codes_table_token_unique": {
+          "name": "login_codes_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "login_codes_table_user_id_users_table_id_fk": {
+          "name": "login_codes_table_user_id_users_table_id_fk",
+          "tableFrom": "login_codes_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_cache_table": {
+      "name": "movie_cache_table",
+      "columns": {
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movie_cache_table_movieId_movies_table_id_fk": {
+          "name": "movie_cache_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_cache_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_directors_table": {
+      "name": "movie_directors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "directorId": {
+          "name": "directorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "movie_directors_movie_id_director_id_unique": {
+          "name": "movie_directors_movie_id_director_id_unique",
+          "columns": [
+            "movieId",
+            "directorId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "movie_directors_table_movieId_movies_table_id_fk": {
+          "name": "movie_directors_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_directors_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movie_directors_table_directorId_directors_table_id_fk": {
+          "name": "movie_directors_table_directorId_directors_table_id_fk",
+          "tableFrom": "movie_directors_table",
+          "tableTo": "directors_table",
+          "columnsFrom": [
+            "directorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies_table": {
+      "name": "movies_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "externalDatabaseMovieId": {
+          "name": "externalDatabaseMovieId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backgroundImage": {
+          "name": "backgroundImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posterImage": {
+          "name": "posterImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runningMinutes": {
+          "name": "runningMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "releaseDate": {
+          "name": "releaseDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "movies_table_externalDatabaseMovieId_unique": {
+          "name": "movies_table_externalDatabaseMovieId_unique",
+          "columns": [
+            "externalDatabaseMovieId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reauth_tokens_table": {
+      "name": "reauth_tokens_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reauth_tokens_table_token_unique": {
+          "name": "reauth_tokens_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "reauth_tokens_table_user_id_users_table_id_fk": {
+          "name": "reauth_tokens_table_user_id_users_table_id_fk",
+          "tableFrom": "reauth_tokens_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_tokens_table": {
+      "name": "session_tokens_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_tokens_table_token_unique": {
+          "name": "session_tokens_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_tokens_table_user_id_users_table_id_fk": {
+          "name": "session_tokens_table_user_id_users_table_id_fk",
+          "tableFrom": "session_tokens_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "streaming_services_table": {
+      "name": "streaming_services_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "streaming_services_table_slug_unique": {
+          "name": "streaming_services_table_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "temp_session_tokens_table": {
+      "name": "temp_session_tokens_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_hmac": {
+          "name": "email_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_email": {
+          "name": "encrypted_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "temp_session_tokens_table_token_unique": {
+          "name": "temp_session_tokens_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_emails_table": {
+      "name": "user_emails_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_email": {
+          "name": "encrypted_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_hmac": {
+          "name": "email_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_emails_table_email_hmac_unique": {
+          "name": "user_emails_table_email_hmac_unique",
+          "columns": [
+            "email_hmac"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_emails_table_user_id_users_table_id_fk": {
+          "name": "user_emails_table_user_id_users_table_id_fk",
+          "tableFrom": "user_emails_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users_table": {
+      "name": "users_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_table_publicId_unique": {
+          "name": "users_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watched_items_table": {
+      "name": "watched_items_table",
+      "columns": {
+        "list_item_id": {
+          "name": "list_item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watched_at": {
+          "name": "watched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watched_items_table_list_item_id_list_items_table_id_fk": {
+          "name": "watched_items_table_list_item_id_list_items_table_id_fk",
+          "tableFrom": "watched_items_table",
+          "tableTo": "list_items_table",
+          "columnsFrom": [
+            "list_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -250,15 +250,22 @@
     {
       "idx": 35,
       "version": "6",
-      "when": 1743379200001,
-      "tag": "0035_add_encrypted_email_to_temp_tokens",
+      "when": 1775013690748,
+      "tag": "0035_youthful_siren",
       "breakpoints": true
     },
     {
       "idx": 36,
       "version": "6",
-      "when": 1743379200002,
-      "tag": "0036_revert_public_id_protect_ip",
+      "when": 1775018175656,
+      "tag": "0036_fixed_fantastic_four",
+      "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "6",
+      "when": 1775100000000,
+      "tag": "0037_fix_login_tables",
       "breakpoints": true
     }
   ]


### PR DESCRIPTION
## 概要

永続化の際にメールアドレス・IPアドレスを暗号化する変更を再適用。
ユーザーのメールアドレスをメニュー内に表示。

## 変更内容

スナップショットとマイグレーションファイルとの整合性が崩れてしまっていた。
ファイルを作り直して改めてマイグレーションを適用。

メニュー内、メールアドレスの変更リンクそばに現在のアドレスを表記。