### PR TITLE
サーバーアクションで使用する現在日時をクライアントから渡さないよう修正

### DIFF
--- a/app/login/components/Form/index.tsx
+++ b/app/login/components/Form/index.tsx
@@ -51,9 +51,9 @@ export default function LoginForm() {
 	return (
 		<Layout>
 			<VerifyForm
-				sendAction={() => sendLoginCode(emailRef.current, new Date())}
+				sendAction={() => sendLoginCode(emailRef.current)}
 				verifyAction={async (code): Promise<Result> => {
-					const result = await login(code, new Date());
+					const result = await login(code);
 					if (result.success) {
 						loginDataRef.current = result.data;
 						return { success: true };

--- a/app/register/components/RegisterForm/index.tsx
+++ b/app/register/components/RegisterForm/index.tsx
@@ -93,7 +93,6 @@ export default function RegisterForm({ email, token }: Props) {
 				email,
 				tempToken: token,
 				localUserList,
-				now: new Date(),
 			});
 
 			if (result.success) {

--- a/features/auth/actions/login.test.ts
+++ b/features/auth/actions/login.test.ts
@@ -81,10 +81,6 @@ async function insertLoginCode({
 }
 
 describe("login", () => {
-	const now = new Date("2026-02-16T00:00:00.000Z");
-	const loginCodeExpiresAt = new Date("2026-02-16T00:10:00.000Z");
-	const sessionTokenExpiresAt = new Date("2026-03-18T00:00:00.000Z");
-	const tempSessionTokenExpiresAt = new Date("2026-02-16T00:15:00.000Z");
 	const expectedDeviceId = "c5232d93874ea7f5";
 	const email = "verify-login-code-test@example.com";
 	let loginCode = "";
@@ -104,19 +100,22 @@ describe("login", () => {
 
 		loginCode = generateLoginCode();
 
+		const loginCodeCreatedAt = new Date();
+		const loginCodeExpiresAt = new Date(Date.now() + 10 * 60 * 1000);
+
 		await db.transaction(async (tx) => {
 			await insertLoginCode({
 				tx,
 				email,
 				token: hashLoginCode(loginCode),
 				expiresAt: loginCodeExpiresAt,
-				createdAt: now,
+				createdAt: loginCodeCreatedAt,
 			});
 		});
 	});
 
 	it("ユーザーが入力した認証コードが有効であれば、30日間有効のトークンを新規に発行して認証済みの状態にする", async () => {
-		const result = await login(loginCode, now);
+		const result = await login(loginCode);
 
 		expect(result.success).toBe(true);
 		if (!result.success) {
@@ -143,7 +142,7 @@ describe("login", () => {
 				httpOnly: true,
 				sameSite: "lax",
 				secure: true,
-				expires: sessionTokenExpiresAt,
+				expires: expect.any(Date),
 			}),
 		);
 
@@ -167,8 +166,8 @@ describe("login", () => {
 		expect(savedSessionToken.token).toBe(cookieValue);
 		expect(savedSessionToken.userId).not.toBeNull();
 		expect(savedSessionToken.deviceId).toBe(expectedDeviceId);
-		expect(savedSessionToken.createdAt).toEqual(now);
-		expect(savedSessionToken.expiresAt).toEqual(sessionTokenExpiresAt);
+		expect(savedSessionToken.createdAt).toBeInstanceOf(Date);
+		expect(savedSessionToken.expiresAt.getTime() - savedSessionToken.createdAt.getTime()).toBe(30 * 24 * 60 * 60 * 1000);
 
 		const [attempt] = await db
 			.select()
@@ -191,18 +190,20 @@ describe("login", () => {
 	it("メールアドレスが未登録だった場合は新規ユーザーとし、15分有効な仮認証トークンを発行する", async () => {
 		const newUserEmail = "verify-login-code-new-user@example.com";
 		const newUserLoginCode = generateLoginCode();
+		const newUserLoginCodeCreatedAt = new Date();
+		const newUserLoginCodeExpiresAt = new Date(Date.now() + 10 * 60 * 1000);
 
 		await db.transaction(async (tx) => {
 			await insertLoginCode({
 				tx,
 				email: newUserEmail,
 				token: hashLoginCode(newUserLoginCode),
-				expiresAt: loginCodeExpiresAt,
-				createdAt: now,
+				expiresAt: newUserLoginCodeExpiresAt,
+				createdAt: newUserLoginCodeCreatedAt,
 			});
 		});
 
-		const result = await login(newUserLoginCode, now);
+		const result = await login(newUserLoginCode);
 
 		expect(result.success).toBe(true);
 		if (!result.success) {
@@ -221,7 +222,7 @@ describe("login", () => {
 				httpOnly: true,
 				sameSite: "lax",
 				secure: true,
-				expires: tempSessionTokenExpiresAt,
+				expires: expect.any(Date),
 			}),
 		);
 		const [[tempCookieKey, tempCookieValue, tempCookieOptions]] =
@@ -233,7 +234,7 @@ describe("login", () => {
 				httpOnly: true,
 				sameSite: "lax",
 				secure: true,
-				expires: tempSessionTokenExpiresAt,
+				expires: expect.any(Date),
 			}),
 		);
 
@@ -256,8 +257,8 @@ describe("login", () => {
 
 		expect(tempToken.token).toBe(tempCookieValue);
 		expect(tempToken.deviceId).toBe(expectedDeviceId);
-		expect(tempToken.createdAt).toEqual(now);
-		expect(tempToken.expiresAt).toEqual(tempSessionTokenExpiresAt);
+		expect(tempToken.createdAt).toBeInstanceOf(Date);
+		expect(tempToken.expiresAt.getTime() - tempToken.createdAt.getTime()).toBe(15 * 60 * 1000);
 
 		const [attempt] = await db
 			.select()

--- a/features/auth/actions/login.ts
+++ b/features/auth/actions/login.ts
@@ -9,13 +9,13 @@ import { loginService } from "../services/loginService";
 
 export async function login(
 	loginCode: string,
-	now: Date,
 ): Promise<
 	Result<{
 		email: string;
 		isNewUser: boolean;
 	}>
 > {
+	const now = new Date();
 	const parsed = loginCodeSchema.safeParse({ value: loginCode });
 
 	if (!parsed.success) {

--- a/features/auth/actions/sendLoginCode.test.ts
+++ b/features/auth/actions/sendLoginCode.test.ts
@@ -75,7 +75,6 @@ function hashLoginCode(loginCode: string) {
 }
 
 describe("sendLoginCode", () => {
-	const now = new Date("2026-02-16T00:00:00.000Z");
 	const existingUserEmail = "send-login-code-test@example.com";
 	const unregisteredUserEmail = "send-login-code-unregistered@example.com";
 
@@ -121,7 +120,7 @@ describe("sendLoginCode", () => {
 	it("【既存ユーザー】10分間有効な数字6桁の認証コードを発行し、入力されたメールアドレスへ送信する", async () => {
 		const existingUser = await seedExistingUser();
 
-		const result = await sendLoginCode(existingUserEmail, now);
+		const result = await sendLoginCode(existingUserEmail);
 
 		expect(result).toEqual({ success: true });
 
@@ -154,10 +153,8 @@ describe("sendLoginCode", () => {
 		}
 
 		expect(savedToken.userId).toBe(existingUser.id);
-		expect(savedToken.createdAt).toEqual(now);
-		expect(savedToken.expiresAt).toEqual(
-			new Date(now.getTime() + 10 * 60 * 1000),
-		);
+		expect(savedToken.createdAt).toBeInstanceOf(Date);
+		expect(savedToken.expiresAt.getTime() - savedToken.createdAt.getTime()).toBe(10 * 60 * 1000);
 		expect(savedToken.token).toBe(hashLoginCode(templateArg.loginCode));
 
 		const [attempt] = await db
@@ -175,7 +172,7 @@ describe("sendLoginCode", () => {
 	});
 
 	it("【未登録ユーザー】10分間有効な数字6桁の認証コードを発行し、入力されたメールアドレスへ送信する", async () => {
-		const result = await sendLoginCode(unregisteredUserEmail, now);
+		const result = await sendLoginCode(unregisteredUserEmail);
 
 		expect(result).toEqual({ success: true });
 
@@ -208,10 +205,8 @@ describe("sendLoginCode", () => {
 		}
 
 		expect(savedToken.userId).toBeNull();
-		expect(savedToken.createdAt).toEqual(now);
-		expect(savedToken.expiresAt).toEqual(
-			new Date(now.getTime() + 10 * 60 * 1000),
-		);
+		expect(savedToken.createdAt).toBeInstanceOf(Date);
+		expect(savedToken.expiresAt.getTime() - savedToken.createdAt.getTime()).toBe(10 * 60 * 1000);
 		expect(savedToken.token).toBe(hashLoginCode(templateArg.loginCode));
 
 		const [attempt] = await db
@@ -232,7 +227,8 @@ describe("sendLoginCode", () => {
 		const existingUser = await seedExistingUser();
 
 		const oldLoginCode = "123456";
-		const oldExpiresAt = new Date(now.getTime() + 5 * 60 * 1000);
+		const setupTime = new Date();
+		const oldExpiresAt = new Date(setupTime.getTime() + 5 * 60 * 1000);
 
 		await db.insert(loginCodesTable).values({
 			token: hashLoginCode(oldLoginCode),
@@ -240,10 +236,10 @@ describe("sendLoginCode", () => {
 			encryptedEmail: encrypt(existingUserEmail),
 			userId: existingUser.id,
 			expiresAt: oldExpiresAt,
-			createdAt: new Date(now.getTime() - 60 * 1000),
+			createdAt: new Date(setupTime.getTime() - 60 * 1000),
 		});
 
-		await sendLoginCode(existingUserEmail, now);
+		await sendLoginCode(existingUserEmail);
 
 		const savedTokens = await db
 			.select()
@@ -261,9 +257,7 @@ describe("sendLoginCode", () => {
 		const [templateArg] = mockLoginMailTemplate.mock.calls[0];
 		expect(savedToken.token).toBe(hashLoginCode(templateArg.loginCode));
 		expect(savedToken.token).not.toBe(hashLoginCode(oldLoginCode));
-		expect(savedToken.createdAt).toEqual(now);
-		expect(savedToken.expiresAt).toEqual(
-			new Date(now.getTime() + 10 * 60 * 1000),
-		);
+		expect(savedToken.createdAt).toBeInstanceOf(Date);
+		expect(savedToken.expiresAt.getTime() - savedToken.createdAt.getTime()).toBe(10 * 60 * 1000);
 	});
 });

--- a/features/auth/actions/sendLoginCode.ts
+++ b/features/auth/actions/sendLoginCode.ts
@@ -8,11 +8,11 @@ import { sendLoginCodeService } from "../services/sendLoginCodeService";
 
 const sendLoginCodeSchema = z.object({
 	email: z.email(),
-	now: z.date(),
 });
 
-export async function sendLoginCode(email: string, now: Date): Promise<Result> {
-	const parsed = sendLoginCodeSchema.safeParse({ email, now });
+export async function sendLoginCode(email: string): Promise<Result> {
+	const now = new Date();
+	const parsed = sendLoginCodeSchema.safeParse({ email });
 
 	if (!parsed.success) {
 		console.error(parsed.error.message);

--- a/features/list/actions/storeListItem.test.ts
+++ b/features/list/actions/storeListItem.test.ts
@@ -33,7 +33,6 @@ async function assertStoreMovieResult({
 	const result = await storeListItem({
 		publicListId,
 		movie,
-		now: new Date(),
 	});
 
 	expect(result.success).toBe(true);
@@ -535,7 +534,6 @@ describe("storeMovie", () => {
 		const result = await storeListItem({
 			publicListId: testPublicListId,
 			movie: watchedMovie,
-			now: new Date("2026-03-21T00:00:00.000Z"),
 		});
 
 		expect(result.success).toBe(true);
@@ -564,7 +562,6 @@ describe("storeMovie", () => {
 		const firstResult = await storeListItem({
 			publicListId: testPublicListId,
 			movie: firstMovie,
-			now: new Date(),
 		});
 
 		expect(firstResult.success).toBe(true);
@@ -572,7 +569,6 @@ describe("storeMovie", () => {
 		const secondResult = await storeListItem({
 			publicListId: testPublicListId,
 			movie: secondMovie,
-			now: new Date(),
 		});
 
 		expect(secondResult.success).toBe(false);
@@ -610,7 +606,6 @@ describe("storeMovie", () => {
 		const result = await storeListItem({
 			publicListId: crypto.randomUUID(),
 			movie,
-			now: new Date(),
 		});
 
 		expect(result).toEqual({
@@ -646,7 +641,6 @@ describe("storeMovie", () => {
 		const result = await storeListItem({
 			publicListId: testPublicListId,
 			movie: invalidMovie,
-			now: new Date(),
 		});
 
 		expect(result).toEqual({

--- a/features/list/actions/storeListItem.ts
+++ b/features/list/actions/storeListItem.ts
@@ -9,24 +9,20 @@ import { storeListItemService } from "../services/storeListItemService";
 const storeListItemSchema = z.object({
 	publicListId: z.uuid(),
 	movie: listItemSchema,
-	now: z.date(),
 });
 
 type Args = {
 	publicListId: string;
 	movie: ListItem;
-	now: Date;
 };
 
 export async function storeListItem({
 	publicListId,
 	movie,
-	now,
 }: Args): Promise<Result<ListItem>> {
 	const parsed = storeListItemSchema.safeParse({
 		publicListId,
 		movie,
-		now,
 	});
 
 	if (!parsed.success) {
@@ -39,6 +35,8 @@ export async function storeListItem({
 			},
 		};
 	}
+
+	const now = new Date();
 
 	return await storeListItemService({
 		publicListId,

--- a/features/list/hooks/useSubmitMovie.ts
+++ b/features/list/hooks/useSubmitMovie.ts
@@ -34,7 +34,6 @@ export const useSubmitMovie = ({ onSuccess }: { onSuccess?: () => void }) => {
 			const result = await storeListItem({
 				publicListId,
 				movie,
-				now: new Date(),
 			});
 
 			setSuccess(result.success);

--- a/features/movieDatabase/actions/getDirectorsFromExternalMovieDatabase.ts
+++ b/features/movieDatabase/actions/getDirectorsFromExternalMovieDatabase.ts
@@ -21,8 +21,8 @@ type Credits = {
 
 export async function getDirectorsFromExternalMovieDatabase(
 	externalApiMovieId: number,
-	now: Date,
 ): Promise<Result<string[]>> {
+	const now = new Date();
 	const externalDatabaseMovieId = externalApiMovieId.toString();
 	const cacheThreshold = new Date(now);
 	cacheThreshold.setMonth(cacheThreshold.getMonth() - 6);

--- a/features/movieDatabase/actions/getMovieFromExternalMovieDatabase.ts
+++ b/features/movieDatabase/actions/getMovieFromExternalMovieDatabase.ts
@@ -13,8 +13,8 @@ type OfficialMovieInfo = TmdbMovieResponse & {
 
 export async function getMovieFromExternalMovieDatabase(
 	externalApiMovieId: number,
-	now: Date,
 ): Promise<Result<OfficialMovieInfo>> {
+	const now = new Date();
 	const externalDatabaseMovieId = externalApiMovieId.toString();
 	const cacheThreshold = new Date(now);
 	cacheThreshold.setMonth(cacheThreshold.getMonth() - 6);

--- a/features/movieDatabase/hooks/useExternalMovieDatabase.ts
+++ b/features/movieDatabase/hooks/useExternalMovieDatabase.ts
@@ -70,11 +70,9 @@ export const useExternalMovieDatabase = ({ movie }: Props) => {
 				return null;
 			}
 
-			const now = new Date();
-
 			const [officialMovieInfo, directorsInfo] = await Promise.all([
-				getMovieFromExternalMovieDatabase(externalApiMovieId, now),
-				getDirectorsFromExternalMovieDatabase(externalApiMovieId, now),
+				getMovieFromExternalMovieDatabase(externalApiMovieId),
+				getDirectorsFromExternalMovieDatabase(externalApiMovieId),
 			]);
 
 			if (!officialMovieInfo.success || !directorsInfo.success) {

--- a/features/user/actions/registerUser.ts
+++ b/features/user/actions/registerUser.ts
@@ -31,14 +31,13 @@ export async function registerUser({
 	userId,
 	tempToken,
 	localUserList,
-	now,
 }: {
 	email: string;
 	userId: string;
 	tempToken: string;
 	localUserList: LocalList;
-	now: Date;
 }): Promise<Result<{ userId: string; publicListId: string }>> {
+	const now = new Date();
 	const tempSession = await verifyTempSessionToken({ tempToken, now });
 
 	if (!tempSession) {


### PR DESCRIPTION
## 概要

サーバーの処理内で使用する現在時刻を、クライアントから引数で渡していた。
これをサーバー内で取得するように修正。

以下のセキュリティリスクに対応する。

- レート制限回避
- 期限切れのトークンやログインコードの再利用
- キャッシュ有効期限の操作