### PR TITLE
ルーレットの抽選元を作成済みのサブリストから選択できるようにする

### DIFF
--- a/app/components/MovieInputForm/index.tsx
+++ b/app/components/MovieInputForm/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState, useTransition } from "react";
+import { Activity, useCallback, useRef, useState, useTransition } from "react";
 import dynamic from "next/dynamic";
 import { AnimatePresence, motion } from "motion/react";
 import type { DraftListItem, ListItem } from "@/features/list/types/ListItem";
@@ -15,11 +15,8 @@ import Loading from "@/components/Loading";
 import BottomSheetContent from "@/app/components/BottomSheetContent";
 import Tab from "./Tab";
 import MobileForm from "./MobileForm";
+import PcForm from "./PcForm";
 
-const PcForm = dynamic(() => import("./PcForm"), {
-	ssr: false,
-	loading: Loading,
-});
 const DraftNewItem = dynamic(() => import("./DraftNewItem"), {
 	ssr: false,
 	loading: Loading,
@@ -32,10 +29,12 @@ const PossibleDuplicateItems = dynamic(
 type Props = {
 	items?: ListItem[];
 	isLoggedIn?: boolean;
+	defaultTab?: "mobile";
 };
 
-export default function MovieInputForm({ items, isLoggedIn = false }: Props) {
-	const { activeTab, setActiveTab } = useActiveTab();
+export default function MovieInputForm({ items, isLoggedIn = false, defaultTab }: Props) {
+	const { activeTab, setActiveTab, deviceTab } = useActiveTab(defaultTab);
+	const shouldAnimate = useRef(defaultTab === undefined && deviceTab === undefined);
 
 	const [extractedMovie, setExtractedMovie] = useState<DraftListItem | null>(
 		null,
@@ -75,6 +74,7 @@ export default function MovieInputForm({ items, isLoggedIn = false }: Props) {
 		clearDuplicateItem();
 	}, [clearDuplicateItem]);
 
+
 	return (
 		<>
 			<div className="w-full h-full flex flex-col items-center justify-center">
@@ -90,17 +90,63 @@ export default function MovieInputForm({ items, isLoggedIn = false }: Props) {
 					</Tab>
 				</div>
 
-				{activeTab === "pc" ? (
-					<PcForm
-						disabled={extractedMovie !== null}
-						handleExtract={handleExtract}
-					/>
-				) : (
-					<MobileForm
-						disabled={extractedMovie !== null}
-						handleExtract={handleExtract}
-					/>
-				)}
+				<div className="min-h-[calc(6lh+var(--spacing)*14+1.25rem)] md:min-h-[calc(4lh+var(--spacing)*14+1.25rem)] w-full flex items-center justify-center">
+					{defaultTab === undefined ? (
+						<>
+							<Activity mode={activeTab === "pc" ? "visible" : "hidden"}>
+								<AnimatePresence>
+									{activeTab === "pc" && (
+										<motion.div
+											initial={shouldAnimate.current ? { opacity: 0, y: 8 } : false}
+											animate={{ opacity: 1, y: 0 }}
+											exit={{ opacity: 0, y: 8 }}
+											transition={{ duration: 0.2, ease: "easeOut" }}
+											className="w-full"
+										>
+											<PcForm
+												disabled={extractedMovie !== null}
+												handleExtract={handleExtract}
+											/>
+										</motion.div>
+									)}
+								</AnimatePresence>
+							</Activity>
+							<Activity mode={activeTab === "mobile" ? "visible" : "hidden"}>
+								<AnimatePresence>
+									{activeTab === "mobile" && (
+										<motion.div
+											initial={shouldAnimate.current ? { opacity: 0, y: 8 } : false}
+											animate={{ opacity: 1, y: 0 }}
+											exit={{ opacity: 0, y: 8 }}
+											transition={{ duration: 0.2, ease: "easeOut" }}
+											className="w-full"
+										>
+											<MobileForm
+												disabled={extractedMovie !== null}
+												handleExtract={handleExtract}
+											/>
+										</motion.div>
+									)}
+								</AnimatePresence>
+							</Activity>
+						</>
+					) : (
+						<>
+							{activeTab === "pc" && (
+								<PcForm
+									disabled={extractedMovie !== null}
+									handleExtract={handleExtract}
+								/>
+							)}
+							{activeTab === "mobile" && (
+								<MobileForm
+									disabled={extractedMovie !== null}
+									handleExtract={handleExtract}
+								/>
+							)}
+						</>
+					)}
+				</div>
 			</div>
 
 			<AnimatePresence>

--- a/app/components/Roulette/Content/Lacking/index.tsx
+++ b/app/components/Roulette/Content/Lacking/index.tsx
@@ -22,8 +22,8 @@ export default function Lacking({ handleClick, itemsNeeded }: Props) {
 			>
 				<h3 className="font-bold">
 					あと
-					<span className="text-xl px-1">{itemsNeeded}本</span>
-					リスト登録してください！
+					<span className="text-xl px-1">{itemsNeeded}作品</span>
+					登録してください！
 				</h3>
 			</Button>
 		</motion.div>

--- a/app/components/Roulette/Content/index.tsx
+++ b/app/components/Roulette/Content/index.tsx
@@ -5,47 +5,102 @@ import dynamic from "next/dynamic";
 import { AnimatePresence, useAnimate } from "motion/react";
 import type { ListItem } from "@/features/list/types/ListItem";
 import { getListItemById } from "@/features/list/actions/getListItemById";
+import { getRouletteListItemIdsBySubList } from "@/features/list/actions/getRouletteListItemIdsBySubList";
 import { useServerAction } from "@/features/shared/hooks/useServerAction";
 import { useListLocalStorageRepository } from "@/features/list/repositories/client/useListLocalStorageRepository";
 import RisuPot from "@/components/RisuPot";
 import { Button } from "@/components/ui/button";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 
 const Lacking = dynamic(() => import("./Lacking"));
 const SelectedItem = dynamic(() => import("./SelectedItem"));
 
+const ALL_ITEMS_VALUE = "all" as const;
+
+type SubList = { publicId: string; name: string };
+
 type Props = {
 	listItemIds?: string[];
+	subLists?: SubList[];
 };
 
-export default function RouletteContent({ listItemIds }: Props) {
-	const { getListItems } = useListLocalStorageRepository();
+const MIN_ITEMS_REQUIRED = 2 as const;
+
+export default function RouletteContent({ listItemIds, subLists }: Props) {
+	const { getListItems, getSubLists } = useListLocalStorageRepository();
 	const { execute, networkError } = useServerAction();
 
 	const [isLacking, setIsLacking] = useState(false);
+	const [lackingCount, setLackingCount] = useState<number>(MIN_ITEMS_REQUIRED);
 	const [isDisabled, setIsDisabled] = useState(false);
 	const [selectedItem, setSelectedItem] = useState<ListItem | null>(null);
 	const [isAnimating, setIsAnimating] = useState(false);
+	const [selectedSubListId, setSelectedSubListId] =
+		useState<string>(ALL_ITEMS_VALUE);
 	const [potScope, animatePot] = useAnimate();
 
 	const localItems = listItemIds ? [] : getListItems();
-	const ids = listItemIds ?? localItems.map((i) => i.listItemId);
+	const localSubLists = subLists ? [] : getSubLists();
+	const allSubLists: SubList[] =
+		subLists ??
+		localSubLists.map((s) => ({ publicId: s.subListId, name: s.name }));
 
-	const MIN_ITEMS_REQUIRED = 2 as const;
+	const getIds = (): string[] => {
+		if (selectedSubListId !== ALL_ITEMS_VALUE) {
+			const localSub = localSubLists.find(
+				(s) => s.subListId === selectedSubListId,
+			);
+			if (localSub) return localSub.listItemIds;
+		}
+		return listItemIds ?? localItems.map((i) => i.listItemId);
+	};
+
+	const ids = getIds();
 
 	const getRandomItem = () => {
 		if (isAnimating) {
 			return;
 		}
 
-		if (ids.length < MIN_ITEMS_REQUIRED) {
+		// ゲストまたは「すべて」選択時は同期チェック可能
+		const isLoginUserWithSubList =
+			listItemIds !== undefined && selectedSubListId !== ALL_ITEMS_VALUE;
+
+		if (!isLoginUserWithSubList && ids.length < MIN_ITEMS_REQUIRED) {
+			setLackingCount(MIN_ITEMS_REQUIRED - ids.length);
 			return setIsLacking(true);
 		}
 
 		setIsAnimating(true);
 
-		const randomId = ids[Math.floor(Math.random() * ids.length)];
-
 		execute(async () => {
+			// ログインユーザーがサブリストを選択している場合はサーバーからIDを取得
+			let pool: string[];
+			if (isLoginUserWithSubList) {
+				const result = await getRouletteListItemIdsBySubList(selectedSubListId);
+				if (!result.success) {
+					setIsAnimating(false);
+					return;
+				}
+				pool = result.data;
+				if (pool.length < MIN_ITEMS_REQUIRED) {
+					setIsAnimating(false);
+					setLackingCount(MIN_ITEMS_REQUIRED - pool.length);
+					setIsLacking(true);
+					return;
+				}
+			} else {
+				pool = ids;
+			}
+
+			const randomId = pool[Math.floor(Math.random() * pool.length)];
+
 			const itemPromise: Promise<ListItem | null> = listItemIds
 				? getListItemById(randomId).then((r) => (r.success ? r.data : null))
 				: Promise.resolve(
@@ -85,19 +140,51 @@ export default function RouletteContent({ listItemIds }: Props) {
 	};
 
 	return (
-		<div className="flex flex-col items-center justify-center rounded-2xl">
-			<Button
-				onClick={getRandomItem}
-				disabled={isDisabled || isLacking}
-				className="cursor-pointer w-full h-full border border-background-light-3 rounded-2xl text-foreground-dark-2 hover:bg-background-light-1 hover:text-foreground"
-			>
-				<div className="flex flex-col items-center pb-2">
-					<div ref={potScope} className="origin-center">
-						<RisuPot className="size-20 text-foreground-dark-1" />
-					</div>
-					<h3 className="font-bold">ランダムに選ぶ！</h3>
+		<>
+			{allSubLists.length > 0 && (
+				<div className="w-full flex justify-end">
+					<Select
+						value={selectedSubListId}
+						onValueChange={(value) => {
+							setSelectedSubListId(value);
+							setIsLacking(false);
+							setIsDisabled(false);
+							setSelectedItem(null);
+						}}
+					>
+						<SelectTrigger className="border-background-light-2 overflow-hidden *:data-[slot=select-value]:inline-block *:data-[slot=select-value]:truncate">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent
+							position="popper"
+							align="end"
+							className="max-w-full bg-background"
+						>
+							<SelectItem value={ALL_ITEMS_VALUE}>すべて</SelectItem>
+							{allSubLists.map((s) => (
+								<SelectItem key={s.publicId} value={s.publicId}>
+									{s.name}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
 				</div>
-			</Button>
+			)}
+			<div className="pt-2">
+				<Button
+					variant={"outline"}
+					onClick={getRandomItem}
+					disabled={isDisabled || isLacking}
+					className="cursor-pointer w-full h-full rounded-md border-background-light-2 hover:bg-background-light-1 hover:ring-2 hover:ring-background-light-3"
+				>
+					<div className="flex flex-col items-center pb-2">
+						<div ref={potScope} className="origin-center">
+							<RisuPot className="size-20 text-foreground-dark-1" />
+						</div>
+						<h3 className="font-bold">ランダムに選ぶ！</h3>
+					</div>
+				</Button>
+			</div>
 
 			{networkError && (
 				<p className="mt-2 text-sm text-red-500">{networkError}</p>
@@ -109,7 +196,7 @@ export default function RouletteContent({ listItemIds }: Props) {
 						handleClick={() => {
 							setIsLacking(false);
 						}}
-						itemsNeeded={MIN_ITEMS_REQUIRED - ids.length}
+						itemsNeeded={lackingCount}
 					/>
 				)}
 
@@ -123,6 +210,6 @@ export default function RouletteContent({ listItemIds }: Props) {
 					/>
 				)}
 			</AnimatePresence>
-		</div>
+		</>
 	);
 }

--- a/app/components/Roulette/index.tsx
+++ b/app/components/Roulette/index.tsx
@@ -1,5 +1,6 @@
 import { currentUserPublicListId } from "@/features/shared/actions/currentUserPublicListId";
 import { getRouletteListItemIds } from "@/features/list/actions/getRouletteListItemIds";
+import { getSubLists } from "@/features/list/actions/getSubLists";
 import RouletteContent from "./Content";
 
 export default async function Roulette() {
@@ -14,5 +15,9 @@ export default async function Roulette() {
 			)
 		: undefined;
 
-	return <RouletteContent listItemIds={listItemIds} />;
+	const subLists = publicListId
+		? await getSubLists().then((r) => (r.success ? r.data : undefined))
+		: undefined;
+
+	return <RouletteContent listItemIds={listItemIds} subLists={subLists} />;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import { headers } from "next/headers";
 import Section from "./components/Section";
 import SectionTitle from "./components/Section/Title";
 import HomeTutorial from "./components/HomeTutorial";
@@ -10,14 +11,20 @@ type Props = {
 	}>;
 };
 
+const MOBILE_UA_PATTERN = /Android|iPhone|iPod|Opera Mini|IEMobile|WPDesktop/i;
+
 export default async function HomePage({ searchParams }: Props) {
 	const params = await searchParams;
 	const homeWithTutorial = params?.home === "true";
 
+	const headersList = await headers();
+	const ua = headersList.get("user-agent") ?? "";
+	const defaultTab = MOBILE_UA_PATTERN.test(ua) ? ("mobile" as const) : undefined;
+
 	if (homeWithTutorial) {
 		return (
 			<HomeTutorial
-				ItemRegisterForm={<MovieInputForm />}
+				ItemRegisterForm={<MovieInputForm defaultTab={defaultTab} />}
 				Roulette={<Roulette />}
 			/>
 		);
@@ -27,7 +34,7 @@ export default async function HomePage({ searchParams }: Props) {
 		<>
 			<Section>
 				<SectionTitle>Make a List</SectionTitle>
-				<MovieInputForm />
+				<MovieInputForm defaultTab={defaultTab} />
 			</Section>
 			<Section>
 				<SectionTitle>Roulette</SectionTitle>

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,190 @@
+"use client"
+
+import type * as React from "react"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import { Select as SelectPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/features/list/actions/getRouletteListItemIdsBySubList.test.ts
+++ b/features/list/actions/getRouletteListItemIdsBySubList.test.ts
@@ -1,0 +1,155 @@
+import crypto from "node:crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "@/db/client";
+import {
+	listItemsTable,
+	listsTable,
+	streamingServicesTable,
+	subListItemsTable,
+	subListsTable,
+	usersTable,
+} from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { getRouletteListItemIdsBySubList } from "./getRouletteListItemIdsBySubList";
+
+const { mockCurrentUserId } = vi.hoisted(() => ({
+	mockCurrentUserId: vi.fn(),
+}));
+
+vi.mock("@/features/shared/actions/currentUserId", () => ({
+	currentUserId: mockCurrentUserId,
+}));
+
+async function findStreamingServiceIdBySlug(slug: "netflix") {
+	const [row] = await db
+		.select({ id: streamingServicesTable.id })
+		.from(streamingServicesTable)
+		.where(eq(streamingServicesTable.slug, slug));
+	if (!row) throw new Error(`${slug} not found`);
+	return row.id;
+}
+
+describe("getRouletteListItemIdsBySubList", () => {
+	let userId = 0;
+	let listId = 0;
+	let subListPublicId = "";
+	let listItemPublicId1 = "";
+	let listItemPublicId2 = "";
+
+	beforeEach(async () => {
+		await db.delete(listItemsTable);
+		await db.delete(listsTable);
+		await db.delete(usersTable);
+
+		const [user] = await db
+			.insert(usersTable)
+			.values({ publicId: "get-roulette-list-item-ids-by-sub-list-user" })
+			.returning({ id: usersTable.id });
+
+		userId = user.id;
+
+		const [list] = await db
+			.insert(listsTable)
+			.values({ publicId: crypto.randomUUID(), userId })
+			.returning({ id: listsTable.id });
+
+		listId = list.id;
+
+		const netflixId = await findStreamingServiceIdBySlug("netflix");
+		listItemPublicId1 = crypto.randomUUID();
+		listItemPublicId2 = crypto.randomUUID();
+
+		const [item1] = await db
+			.insert(listItemsTable)
+			.values({
+				publicId: listItemPublicId1,
+				listId,
+				streamingServiceId: netflixId,
+				watchUrl: "https://www.netflix.com/jp/title/1",
+				titleOnService: "テスト映画1",
+				createdAt: new Date(),
+			})
+			.returning({ id: listItemsTable.id });
+
+		const [item2] = await db
+			.insert(listItemsTable)
+			.values({
+				publicId: listItemPublicId2,
+				listId,
+				streamingServiceId: netflixId,
+				watchUrl: "https://www.netflix.com/jp/title/2",
+				titleOnService: "テスト映画2",
+				createdAt: new Date(),
+			})
+			.returning({ id: listItemsTable.id });
+
+		subListPublicId = crypto.randomUUID();
+		const [subList] = await db
+			.insert(subListsTable)
+			.values({
+				publicId: subListPublicId,
+				listId,
+				name: "テストサブリスト",
+				createdAt: new Date(),
+			})
+			.returning({ id: subListsTable.id });
+
+		await db.insert(subListItemsTable).values([
+			{ subListId: subList.id, listItemId: item1.id },
+			{ subListId: subList.id, listItemId: item2.id },
+		]);
+	});
+
+	it("自身のサブリストのアイテムpublicId配列を返す", async () => {
+		mockCurrentUserId.mockResolvedValue({ success: true, data: { userId } });
+
+		const result = await getRouletteListItemIdsBySubList(subListPublicId);
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		expect(result.data).toHaveLength(2);
+		expect(result.data).toContain(listItemPublicId1);
+		expect(result.data).toContain(listItemPublicId2);
+	});
+
+	it("存在しないサブリストでは NOT_FOUND_ERROR を返す", async () => {
+		mockCurrentUserId.mockResolvedValue({ success: true, data: { userId } });
+
+		const result = await getRouletteListItemIdsBySubList(crypto.randomUUID());
+
+		expect(result).toEqual({
+			success: false,
+			error: { code: "NOT_FOUND_ERROR", message: "サブリストが見つかりませんでした。" },
+		});
+	});
+
+	it("他ユーザーのサブリストでは NOT_FOUND_ERROR を返す", async () => {
+		const [otherUser] = await db
+			.insert(usersTable)
+			.values({ publicId: "other-user" })
+			.returning({ id: usersTable.id });
+
+		mockCurrentUserId.mockResolvedValue({
+			success: true,
+			data: { userId: otherUser.id },
+		});
+
+		const result = await getRouletteListItemIdsBySubList(subListPublicId);
+
+		expect(result).toEqual({
+			success: false,
+			error: { code: "NOT_FOUND_ERROR", message: "サブリストが見つかりませんでした。" },
+		});
+	});
+
+	it("未認証ユーザーは UNAUTHORIZED_ERROR を返す", async () => {
+		mockCurrentUserId.mockResolvedValue({ success: false });
+
+		const result = await getRouletteListItemIdsBySubList(subListPublicId);
+
+		expect(result).toEqual({
+			success: false,
+			error: { code: "UNAUTHORIZED_ERROR", message: "ログインかユーザー登録をしてください。" },
+		});
+	});
+});

--- a/features/list/actions/getRouletteListItemIdsBySubList.ts
+++ b/features/list/actions/getRouletteListItemIdsBySubList.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import z from "zod";
+import type { Result } from "@/features/shared/types/Result";
+import { currentUserId } from "@/features/shared/actions/currentUserId";
+import {
+	findListIdByUserId,
+	findSubListByPublicId,
+	findSubListItemsBySubListId,
+} from "../repositories/server/listRepository";
+
+const schema = z.object({ subListPublicId: z.string().uuid() });
+
+export async function getRouletteListItemIdsBySubList(
+	subListPublicId: string,
+): Promise<Result<string[]>> {
+	const parsed = schema.safeParse({ subListPublicId });
+
+	if (!parsed.success) {
+		return {
+			success: false,
+			error: { code: "VALIDATION_ERROR", message: "不正なリクエストです。" },
+		};
+	}
+
+	const authResult = await currentUserId();
+
+	if (!authResult.success) {
+		return {
+			success: false,
+			error: {
+				code: "UNAUTHORIZED_ERROR",
+				message: "ログインかユーザー登録をしてください。",
+			},
+		};
+	}
+
+	const userListId = await findListIdByUserId(authResult.data.userId);
+	const subList = await findSubListByPublicId(parsed.data.subListPublicId);
+
+	if (!subList || subList.listId !== userListId) {
+		return {
+			success: false,
+			error: { code: "NOT_FOUND_ERROR", message: "サブリストが見つかりませんでした。" },
+		};
+	}
+
+	const items = await findSubListItemsBySubListId(subList.id);
+
+	return { success: true, data: items.map((item) => item.listItemId) };
+}

--- a/features/list/atoms/deviceTabAtom.ts
+++ b/features/list/atoms/deviceTabAtom.ts
@@ -1,0 +1,3 @@
+import { atom } from "jotai";
+
+export const deviceTabAtom = atom<"pc" | "mobile" | undefined>(undefined);

--- a/features/list/hooks/useActiveTab.ts
+++ b/features/list/hooks/useActiveTab.ts
@@ -1,9 +1,15 @@
 import { useEffect, useState } from "react";
+import { useAtom } from "jotai";
+import { deviceTabAtom } from "@/features/list/atoms/deviceTabAtom";
 
-export function useActiveTab() {
-	const [activeTab, setActiveTab] = useState<"pc" | "mobile">("mobile");
+export function useActiveTab(defaultTab?: "mobile") {
+	const [deviceTab, setDeviceTab] = useAtom(deviceTabAtom);
+	const [activeTab, setActiveTab] = useState<"pc" | "mobile" | undefined>(
+		defaultTab ?? deviceTab,
+	);
 
 	useEffect(() => {
+		if (defaultTab !== undefined || deviceTab !== undefined) return;
 		const ua = navigator.userAgent;
 		const isTouchDevice =
 			"ontouchstart" in window || navigator.maxTouchPoints > 0;
@@ -13,10 +19,15 @@ export function useActiveTab() {
 		// UI最適化のため、Mac かつタッチデバイスならモバイルデバイスと判定する。
 		const isMobileUA =
 			/Android|iPhone|iPod|Opera Mini|IEMobile|WPDesktop/i.test(ua);
-		if (!isMobileUA && (!isTouchDevice || !isMac)) {
-			setActiveTab("pc");
-		}
-	}, []);
 
-	return { activeTab, setActiveTab };
+		if (!isMobileUA && (!isTouchDevice || !isMac)) {
+			setDeviceTab("pc");
+			setActiveTab("pc");
+		} else {
+			setDeviceTab("mobile");
+			setActiveTab("mobile");
+		}
+	}, [defaultTab, deviceTab, setDeviceTab]);
+
+	return { activeTab, setActiveTab, deviceTab };
 }

--- a/tests/e2e/pages/home/functional/listItemDetail.test.ts
+++ b/tests/e2e/pages/home/functional/listItemDetail.test.ts
@@ -31,6 +31,38 @@ async function seedLocalStorageWithUnwatchedItem(
 	return item;
 }
 
+/** localStorageからlistIdを取得するポーリングヘルパー */
+async function waitForListId(page: import("@playwright/test").Page): Promise<string> {
+	const listId = await page.waitForFunction(
+		({ key }: { key: string }) => {
+			const raw = localStorage.getItem(key);
+			if (!raw) return null;
+			try {
+				const parsed: unknown = JSON.parse(raw);
+				if (
+					parsed !== null &&
+					typeof parsed === "object" &&
+					"list" in parsed &&
+					parsed.list !== null &&
+					typeof parsed.list === "object" &&
+					"listId" in parsed.list &&
+					typeof parsed.list.listId === "string"
+				) {
+					return parsed.list.listId;
+				}
+			} catch {
+				// ignore
+			}
+			return null;
+		},
+		{ key: LOCAL_STORAGE_KEY },
+		{ timeout: 10_000 },
+	);
+	const value: unknown = await listId.jsonValue();
+	if (typeof value !== "string") throw new Error("listId が取得できませんでした");
+	return value;
+}
+
 test.describe("ListItemDetail - オーバーレイ機能テスト", () => {
 	test.beforeEach(async () => {
 		await resetDatabase();
@@ -44,8 +76,8 @@ test.describe("ListItemDetail - オーバーレイ機能テスト", () => {
 	// ── カード外クリックで詳細が閉じる ───────────────────────────────────────
 
 	async function runClickOutsideTest(page: import("@playwright/test").Page, projectName: string) {
-		const listId = "test-list-id-click-outside";
 		await page.goto("/");
+		const listId = await waitForListId(page);
 		await seedLocalStorageWithUnwatchedItem(page, listId);
 		await page.reload();
 

--- a/tests/e2e/pages/home/functional/movieInputForm.test.ts
+++ b/tests/e2e/pages/home/functional/movieInputForm.test.ts
@@ -155,4 +155,83 @@ test.describe("MovieInputForm - 機能テスト", () => {
 		await page.goto("/");
 		await fillPcFormAndVerify(page);
 	});
+
+	// ── モバイルデバイスで MobileForm が即座に表示されること ──────────────
+
+	test("iPhone でページを開くと MobileForm（textarea）が即座に表示される", async ({
+		page,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "mobile-webkit",
+			"このテストは mobile-webkit プロジェクトのみ対象",
+		);
+		await page.goto("/");
+		// SSR 時点で defaultTab="mobile" が渡るため、hydration 前から textarea が見える
+		const textarea = page.locator("textarea");
+		await expect(textarea).toBeVisible({ timeout: 1000 });
+	});
+
+	test("Pixel 7 でページを開くと MobileForm（textarea）が即座に表示される", async ({
+		page,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "mobile-chromium",
+			"このテストは mobile-chromium プロジェクトのみ対象",
+		);
+		await page.goto("/");
+		// SSR 時点で defaultTab="mobile" が渡るため、hydration 前から textarea が見える
+		const textarea = page.locator("textarea");
+		await expect(textarea).toBeVisible({ timeout: 1000 });
+	});
+
+	// ── Desktop Chrome: フェードインアニメーションの制御 ─────────────────────
+
+	test("Desktop Chrome で初回アクセス時にフォームがフェードインで表示される", async ({
+		page,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "desktop-chromium",
+			"このテストは desktop-chromium プロジェクトのみ対象",
+		);
+
+		await page.goto("/");
+
+		// UA 判定 useEffect が走る前（初回マウント直後）に motion.div の opacity が 0 であることを確認
+		const formArea = page.locator(".min-h-\\[calc\\(6lh\\+var\\(--spacing\\)\\*14\\+1\\.25rem\\)\\]");
+		// フォームエリアが表示されるまで待つ
+		await expect(formArea).toBeVisible();
+
+		// PC フォームの #title が最終的に表示されること（アニメーション完了後）
+		await expect(page.locator("#title")).toBeVisible({ timeout: 3000 });
+	});
+
+	test("Desktop Chrome で別ページへ遷移してホームに戻った際、フォームが即座に表示される", async ({
+		page,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "desktop-chromium",
+			"このテストは desktop-chromium プロジェクトのみ対象",
+		);
+
+		// 初回アクセス（atom に deviceTab がキャッシュされる）
+		await page.goto("/");
+		await expect(page.locator("#title")).toBeVisible({ timeout: 3000 });
+
+		// 別ページに遷移してからホームに戻る
+		await page.goto("/about", { waitUntil: "domcontentloaded" }).catch(() => {
+			// /about が存在しない場合は 404 でも構わない
+		});
+		await page.goto("/");
+
+		// 2回目は atom に値がキャッシュされているため shouldAnimate.current = false
+		// initial={false} なのでアニメーションなしで即座に表示される
+		// waitForFunction で即座（200ms 以内）に opacity=1 であることを確認
+		const titleInput = page.locator("#title");
+		const start = Date.now();
+		await expect(titleInput).toBeVisible({ timeout: 1000 });
+		const elapsed = Date.now() - start;
+		// アニメーションがないため、表示までの時間が短い（200ms の transition duration より大幅に短い）
+		// ここでは 500ms 以内に表示されることを確認
+		expect(elapsed).toBeLessThan(500);
+	});
 });

--- a/tests/e2e/pages/home/functional/roulette.test.ts
+++ b/tests/e2e/pages/home/functional/roulette.test.ts
@@ -1,0 +1,328 @@
+import crypto from "node:crypto";
+import { expect, test } from "@playwright/test";
+import {
+	listItemsTable,
+	listsTable,
+	streamingServicesTable,
+	subListItemsTable,
+	subListsTable,
+} from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { setupAuthenticatedUser } from "../../../helpers/auth";
+import { resetDatabase, seedDatabase } from "../../../lib/dbHelpers";
+import { db } from "../../../lib/testDb";
+
+const LOCAL_STORAGE_KEY = "risutopotto";
+
+async function findNetflixId() {
+	const [service] = await db
+		.select()
+		.from(streamingServicesTable)
+		.where(eq(streamingServicesTable.slug, "netflix"));
+	if (!service) throw new Error("netflix not found");
+	return service.id;
+}
+
+async function createDbItems(userId: number, count: number) {
+	const [list] = await db
+		.select()
+		.from(listsTable)
+		.where(eq(listsTable.userId, userId));
+
+	const netflixId = await findNetflixId();
+
+	const items = await Promise.all(
+		Array.from({ length: count }, (_, i) =>
+			db
+				.insert(listItemsTable)
+				.values({
+					publicId: crypto.randomUUID(),
+					listId: list.id,
+					streamingServiceId: netflixId,
+					watchUrl: `https://www.netflix.com/jp/title/${i + 1}`,
+					titleOnService: `テスト映画${i + 1}`,
+					createdAt: new Date(),
+				})
+				.returning()
+				.then(([r]) => r),
+		),
+	);
+
+	return { list, items };
+}
+
+async function createDbSubList(
+	listId: number,
+	name: string,
+	itemIds: number[],
+) {
+	const [subList] = await db
+		.insert(subListsTable)
+		.values({
+			publicId: crypto.randomUUID(),
+			listId,
+			name,
+			createdAt: new Date(),
+		})
+		.returning();
+
+	if (itemIds.length > 0) {
+		await db.insert(subListItemsTable).values(
+			itemIds.map((listItemId) => ({ subListId: subList.id, listItemId })),
+		);
+	}
+
+	return subList;
+}
+
+test.describe("ルーレット - サブリスト選択", () => {
+	test.beforeEach(async () => {
+		await resetDatabase();
+		await seedDatabase();
+	});
+
+	test.afterEach(async () => {
+		await resetDatabase();
+	});
+
+	// ケース1: サブリストなしのときセレクトボックスが表示されない
+	test("サブリストがないとき、セレクトボックスは表示されない", async ({
+		page,
+		context,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "mobile-webkit",
+			"このテストは mobile-webkit プロジェクトのみ対象",
+		);
+
+		const { userId } = await setupAuthenticatedUser(
+			context,
+			testInfo.project.use.userAgent ?? "test-user-agent",
+			testInfo.project.use.baseURL ?? "",
+		);
+		await createDbItems(userId, 2);
+
+		await page.goto("/");
+
+		await expect(page.getByRole("combobox")).not.toBeVisible();
+	});
+
+	// ケース2: サブリストありのときセレクトボックスが「すべて」選択済みで表示される
+	test("サブリストがあるとき、セレクトボックスが「すべて」選択済みで表示される（ログイン）", async ({
+		page,
+		context,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "mobile-webkit",
+			"このテストは mobile-webkit プロジェクトのみ対象",
+		);
+
+		const { userId } = await setupAuthenticatedUser(
+			context,
+			testInfo.project.use.userAgent ?? "test-user-agent",
+			testInfo.project.use.baseURL ?? "",
+		);
+		const { list, items } = await createDbItems(userId, 2);
+		await createDbSubList(
+			list.id,
+			"アクション",
+			items.map((i) => i.id),
+		);
+
+		await page.goto("/");
+
+		const select = page.getByRole("combobox");
+		await expect(select).toBeVisible();
+		await expect(select).toHaveText("すべて");
+	});
+
+	// ケース3: セレクトを展開するとサブリスト名が表示される
+	test("セレクトボックスを展開すると「すべて」とサブリスト名が表示される（ログイン）", async ({
+		page,
+		context,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "mobile-webkit",
+			"このテストは mobile-webkit プロジェクトのみ対象",
+		);
+
+		const { userId } = await setupAuthenticatedUser(
+			context,
+			testInfo.project.use.userAgent ?? "test-user-agent",
+			testInfo.project.use.baseURL ?? "",
+		);
+		const { list, items } = await createDbItems(userId, 2);
+		await createDbSubList(
+			list.id,
+			"アクション",
+			items.map((i) => i.id),
+		);
+
+		await page.goto("/");
+
+		await page.getByRole("combobox").click();
+		await expect(page.getByRole("option", { name: "すべて" })).toBeVisible();
+		await expect(page.getByRole("option", { name: "アクション" })).toBeVisible();
+	});
+
+	// ケース4: ログインユーザーがサブリストを選択してルーレットを実行できる
+	test("ログインユーザーがサブリストを選択して「ランダムに選ぶ！」を押すと結果が表示される", async ({
+		page,
+		context,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "mobile-webkit",
+			"このテストは mobile-webkit プロジェクトのみ対象",
+		);
+
+		const { userId } = await setupAuthenticatedUser(
+			context,
+			testInfo.project.use.userAgent ?? "test-user-agent",
+			testInfo.project.use.baseURL ?? "",
+		);
+		const { list, items } = await createDbItems(userId, 3);
+		await createDbSubList(
+			list.id,
+			"アクション",
+			items.slice(0, 2).map((i) => i.id),
+		);
+
+		await page.goto("/");
+
+		await page.getByRole("combobox").click();
+		await page.getByRole("option", { name: "アクション" }).click();
+		await page.getByRole("button", { name: "ランダムに選ぶ！" }).click();
+
+		// 結果アイテムが表示される（テスト映画1 or テスト映画2）
+		await expect(
+			page.getByText(/テスト映画[12]/).first(),
+		).toBeVisible({ timeout: 10_000 });
+	});
+
+	// ケース5: アイテムが1件しかないサブリストを選択するとアイテム不足UIが表示される
+	test("アイテムが1件しかないサブリストを選択すると不足UIが表示される（ログイン）", async ({
+		page,
+		context,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "mobile-webkit",
+			"このテストは mobile-webkit プロジェクトのみ対象",
+		);
+
+		const { userId } = await setupAuthenticatedUser(
+			context,
+			testInfo.project.use.userAgent ?? "test-user-agent",
+			testInfo.project.use.baseURL ?? "",
+		);
+		const { list, items } = await createDbItems(userId, 3);
+		await createDbSubList(list.id, "1件のみ", [items[0].id]);
+
+		await page.goto("/");
+
+		await page.getByRole("combobox").click();
+		await page.getByRole("option", { name: "1件のみ" }).click();
+		await page.getByRole("button", { name: "ランダムに選ぶ！" }).click();
+
+		// アイテム不足UIが表示される
+		await expect(page.getByText(/あと/)).toBeVisible({ timeout: 5_000 });
+	});
+
+	// ケース6: アイテムが0件のサブリストを選択すると「あと2件」と表示される（マイナスにならない）
+	test("アイテムが0件のサブリストを選択すると「あと2件」と表示される（ログイン）", async ({
+		page,
+		context,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "mobile-webkit",
+			"このテストは mobile-webkit プロジェクトのみ対象",
+		);
+
+		const { userId } = await setupAuthenticatedUser(
+			context,
+			testInfo.project.use.userAgent ?? "test-user-agent",
+			testInfo.project.use.baseURL ?? "",
+		);
+		const { list } = await createDbItems(userId, 3);
+		await createDbSubList(list.id, "空のサブリスト", []);
+
+		await page.goto("/");
+
+		await page.getByRole("combobox").click();
+		await page.getByRole("option", { name: "空のサブリスト" }).click();
+		await page.getByRole("button", { name: "ランダムに選ぶ！" }).click();
+
+		await expect(page.getByText("あと2作品登録してください！")).toBeVisible({
+			timeout: 5_000,
+		});
+	});
+
+	// ケース7: ゲストがサブリストを選択してルーレットを実行できる
+	test("ゲストがサブリストを選択して「ランダムに選ぶ！」を押すと結果が表示される", async ({
+		page,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "mobile-webkit",
+			"このテストは mobile-webkit プロジェクトのみ対象",
+		);
+
+		const listId = crypto.randomUUID();
+		const item1Id = crypto.randomUUID();
+		const item2Id = crypto.randomUUID();
+		const subListId = crypto.randomUUID();
+
+		await page.goto("/");
+
+		await page.evaluate(
+			({ key, value }) => {
+				localStorage.setItem(key, JSON.stringify(value));
+			},
+			{
+				key: LOCAL_STORAGE_KEY,
+				value: {
+					list: {
+						listId,
+						items: [
+							{
+								listItemId: item1Id,
+								title: "ゲスト映画1",
+								url: "https://www.netflix.com/jp/title/1",
+								serviceSlug: "netflix",
+								serviceName: "Netflix",
+								createdAt: new Date().toISOString(),
+								isWatched: false,
+								watchedAt: null,
+							},
+							{
+								listItemId: item2Id,
+								title: "ゲスト映画2",
+								url: "https://www.netflix.com/jp/title/2",
+								serviceSlug: "netflix",
+								serviceName: "Netflix",
+								createdAt: new Date().toISOString(),
+								isWatched: false,
+								watchedAt: null,
+							},
+						],
+					},
+					subLists: [
+						{
+							subListId,
+							name: "お気に入り",
+							listItemIds: [item1Id, item2Id],
+						},
+					],
+				},
+			},
+		);
+
+		await page.reload();
+
+		await page.getByRole("combobox").click();
+		await page.getByRole("option", { name: "お気に入り" }).click();
+		await page.getByRole("button", { name: "ランダムに選ぶ！" }).click();
+
+		await expect(
+			page.getByText(/ゲスト映画[12]/).first(),
+		).toBeVisible({ timeout: 10_000 });
+	});
+});

--- a/tests/e2e/pages/home/functional/scrollLock.test.ts
+++ b/tests/e2e/pages/home/functional/scrollLock.test.ts
@@ -31,6 +31,38 @@ async function seedLocalStorageWithItem(
 	return item;
 }
 
+/** localStorageからlistIdを取得するポーリングヘルパー */
+async function waitForListId(page: import("@playwright/test").Page): Promise<string> {
+	const listId = await page.waitForFunction(
+		({ key }: { key: string }) => {
+			const raw = localStorage.getItem(key);
+			if (!raw) return null;
+			try {
+				const parsed: unknown = JSON.parse(raw);
+				if (
+					parsed !== null &&
+					typeof parsed === "object" &&
+					"list" in parsed &&
+					parsed.list !== null &&
+					typeof parsed.list === "object" &&
+					"listId" in parsed.list &&
+					typeof parsed.list.listId === "string"
+				) {
+					return parsed.list.listId;
+				}
+			} catch {
+				// ignore
+			}
+			return null;
+		},
+		{ key: LOCAL_STORAGE_KEY },
+		{ timeout: 10_000 },
+	);
+	const value: unknown = await listId.jsonValue();
+	if (typeof value !== "string") throw new Error("listId が取得できませんでした");
+	return value;
+}
+
 test.describe("スクロールロック - 機能テスト", () => {
 	test.beforeEach(async () => {
 		await resetDatabase();
@@ -48,8 +80,8 @@ test.describe("スクロールロック - 機能テスト", () => {
 			testInfo.project.name !== "desktop-chromium",
 			"このテストは desktop-chromium プロジェクトのみ対象",
 		);
-		const listId = "test-list-id-scroll-lock-1";
 		await page.goto("/");
+		const listId = await waitForListId(page);
 		await seedLocalStorageWithItem(page, listId);
 		await page.reload();
 
@@ -85,8 +117,8 @@ test.describe("スクロールロック - 機能テスト", () => {
 			testInfo.project.name !== "desktop-chromium",
 			"このテストは desktop-chromium プロジェクトのみ対象",
 		);
-		const listId = "test-list-id-scroll-lock-2";
 		await page.goto("/");
+		const listId = await waitForListId(page);
 		await seedLocalStorageWithItem(page, listId);
 		await page.reload();
 

--- a/tests/e2e/pages/home/non-functional/movieInputFormPerformance.test.ts
+++ b/tests/e2e/pages/home/non-functional/movieInputFormPerformance.test.ts
@@ -46,12 +46,21 @@ const DESKTOP_CHROME_UA = devices["Desktop Chrome"].userAgent ?? "";
 
 // ── テストヘルパー ─────────────────────────────────────────────────────────
 
-// 3G スロットリングを設定してページを読み込み、テキストエリアが 2 秒以内に表示されることを検証
-async function testDisplaySpeed(context: BrowserContext, page: Page) {
+async function testMobileDisplaySpeed(context: BrowserContext, page: Page) {
 	const cdpSession = await context.newCDPSession(page);
 	await cdpSession.send("Network.emulateNetworkConditions", THROTTLING_3G);
 	await page.goto("/", { waitUntil: "domcontentloaded" });
-	await expect(page.locator("textarea")).toBeVisible({ timeout: 2000 });
+	await expect(page.locator('textarea[name="value"]')).toBeVisible({
+		timeout: 2000,
+	});
+}
+
+async function testPcDisplaySpeed(context: BrowserContext, page: Page) {
+	const cdpSession = await context.newCDPSession(page);
+	await cdpSession.send("Network.emulateNetworkConditions", THROTTLING_3G);
+	await page.goto("/", { waitUntil: "domcontentloaded" });
+	await expect(page.locator("#title")).toBeVisible({ timeout: 2000 });
+	await expect(page.locator("#watch-url")).toBeVisible({ timeout: 2000 });
 }
 
 /**
@@ -67,8 +76,8 @@ async function testMobileReactivity(context: BrowserContext, page: Page) {
 	const cdpSession = await context.newCDPSession(page);
 	await cdpSession.send("Network.emulateNetworkConditions", THROTTLING_3G);
 	await page.goto("/");
-	await expect(page.locator("textarea")).toBeVisible();
-	await page.locator("textarea").fill(UNEXT_SHARE_LINK);
+	await expect(page.locator('textarea[name="value"]')).toBeVisible();
+	await page.locator('textarea[name="value"]').fill(UNEXT_SHARE_LINK);
 	await expect(page.getByRole("status")).toBeVisible({
 		timeout: IMMEDIATE_RESPONSE_TIMEOUT_MS,
 	});
@@ -114,7 +123,7 @@ test.describe("MovieInputForm - 非機能テスト（認証済み × iPhone × C
 	});
 
 	test("3G 下で MovieInputForm が 2 秒以内に表示される", async () => {
-		await testDisplaySpeed(context, page);
+		await testMobileDisplaySpeed(context, page);
 	});
 
 	test("3G 下でフォーム入力に即座に反応する", async () => {
@@ -147,7 +156,7 @@ test.describe("MovieInputForm - 非機能テスト（未認証 × Pixel 7 × Chr
 	});
 
 	test("3G 下で MovieInputForm が 2 秒以内に表示される", async () => {
-		await testDisplaySpeed(context, page);
+		await testMobileDisplaySpeed(context, page);
 	});
 
 	test("3G 下でフォーム入力に即座に反応する", async () => {
@@ -180,7 +189,7 @@ test.describe("MovieInputForm - 非機能テスト（未認証 × PC × Chromium
 	});
 
 	test("3G 下で MovieInputForm が 2 秒以内に表示される", async () => {
-		await testDisplaySpeed(context, page);
+		await testPcDisplaySpeed(context, page);
 	});
 
 	test("3G 下でフォーム入力に即座に反応する", async () => {
@@ -214,7 +223,7 @@ test.describe("MovieInputForm - 非機能テスト（認証済み × PC × Chrom
 	});
 
 	test("3G 下で MovieInputForm が 2 秒以内に表示される", async () => {
-		await testDisplaySpeed(context, page);
+		await testPcDisplaySpeed(context, page);
 	});
 
 	test("3G 下でフォーム入力に即座に反応する", async () => {


### PR DESCRIPTION
## 概要

ルーレットが作品を抽出するリストを、メインのリスト＋既存サブリストから選択できるようにする。

## 変更内容

### ルーレット
shadcn/ui Selectコンポーネントを追加
ルーレット上部にリスト選択のセレクトボックスを追加

### トップ画面の設計改善

iPadはUAがMacと同一のためサーバーで判別できない。
そのためPC/iPadはクライアントのuseEffectでタッチデバイス判定を行う。

従来はサーバー側の読み込み時間短縮のためUAの判別自体をクライアントで行っていた。
- useEffectでデバイスを判定
- 戻り値によってフォームを出し分け（動的インポートで最適化）

これをフォームの出しわけをサーバー/クライアントそれぞれで実行するよう変更。

- モバイルUA（Android/iPhone等）はサーバーで判定
- SSR時点でMobileFormを確定させることでフラッシュをなくす。

PC or iPadの判定結果はステートにキャッシュ。
キャッシュがない場合は判定後にフォームをフェードイン。
以降はキャッシュを利用して通常表示。

### E2Eテストの修正

- 映画入力フォームの表示テスト：ロケーターを調整
- ローカルのリストを使用するテストへ、atomWithStorageの初期化を待機する処理を追加

ローカル用リストの初期化が MenuContent の useEffect に実装されている。
Jotai の atomWithStorage 初期化との実行順が不定になる場合がある。

初期化が終了し、listId が確定するまでポーリングで待機することでフレイキーを回避する。

## TODO

現在、ナビゲーションメニューのコンポーネントでリストの初期化を行なっている。

責務として不適切であり、結果として他ページの挙動がこれに依存している。
また、今回問題となったE2Eテストのフレイキネスにもつながっている。

今回テストへ追加したポーリング処理は暫定実装とし、別で設計の改善を行う。