### PR TITLE
perf: リスト画面の画像表示を高速化（Issue #269）

### DIFF
--- a/app/[publicListId]/components/List/Item/index.tsx
+++ b/app/[publicListId]/components/List/Item/index.tsx
@@ -5,6 +5,7 @@ import { useAtomValue } from "jotai";
 import { formatRelativeDate, formatFullDate } from "@/lib/date";
 import type { ListItem } from "@/features/list/types/ListItem";
 import type { SortKey } from "@/features/list/helpers/sortListItems";
+import { withTmdbImageSize } from "@/features/movieDatabase/helpers/withTmdbImageSize";
 import CheckMarkIcon from "@/components/ui/Icons/CheckMarkIcon";
 import SubListSelectDrawer from "@/app/components/SubListSelectDrawer/SubListSelectDrawer";
 import LocalSubListSelectDrawer from "@/app/components/SubListSelectDrawer/LocalSubListSelectDrawer";
@@ -25,6 +26,7 @@ type LoggedInProps = {
 	subLists: SubList[];
 	checkedSubListIds: string[];
 	sortKey?: SortKey;
+	index: number;
 };
 
 type GuestProps = {
@@ -32,6 +34,7 @@ type GuestProps = {
 	isLoggedIn: false;
 	publicListId: string;
 	sortKey?: SortKey;
+	index: number;
 };
 
 type Props = LoggedInProps | GuestProps;
@@ -58,7 +61,7 @@ const formatDateLabel = (
 };
 
 export default function Item(props: Props) {
-	const { movie, isLoggedIn, publicListId, sortKey } = props;
+	const { movie, isLoggedIn, publicListId, sortKey, index } = props;
 	const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
 	const store = useAtomValue(risutopottoAtom);
@@ -112,11 +115,15 @@ export default function Item(props: Props) {
 								className="w-full h-full flex justify-center"
 							>
 								<div className="h-full aspect-square flex justify-center">
-									<img
-										className="object-contain h-full rounded-sm"
-										src={movie.details?.posterImage}
-										alt=""
-									/>
+									{movie.details.posterImage && (
+										<img
+											className="object-contain h-full rounded-sm"
+											src={withTmdbImageSize(movie.details.posterImage, "w342")}
+											alt=""
+											decoding="async"
+											{...(index >= 3 ? { loading: "lazy" } : { fetchPriority: "high" })}
+										/>
+									)}
 								</div>
 							</SearchButton>
 						) : (
@@ -127,11 +134,15 @@ export default function Item(props: Props) {
 						)}
 					</div>
 
-					<img
-						className="w-full h-full object-cover"
-						src={movie.details?.backgroundImage}
-						alt=""
-					/>
+					{movie.details?.backgroundImage && (
+						<img
+							className="w-full h-full object-cover"
+							src={withTmdbImageSize(movie.details.backgroundImage, "w300")}
+							alt=""
+							decoding="async"
+							{...(index >= 3 ? { loading: "lazy" } : {})}
+						/>
+					)}
 				</div>
 				<div className="flex gap-2 w-full rounded-b-2x pt-4 sm:pt-2">
 					<div>

--- a/app/[publicListId]/components/ListController/index.tsx
+++ b/app/[publicListId]/components/ListController/index.tsx
@@ -188,7 +188,7 @@ export default function ListController({
 				className={`motion-safe:transition-opacity motion-safe:duration-200 ${isPending ? "opacity-40" : "opacity-100"}`}
 			>
 				<ListContainer>
-					{displayedItems.map((movie) => {
+					{displayedItems.map((movie, index) => {
 						const checkedSubListIds =
 							checkedSubListIdsMap.get(movie.listItemId) ?? [];
 						return (
@@ -200,6 +200,7 @@ export default function ListController({
 								subLists={subLists}
 								checkedSubListIds={checkedSubListIds}
 								sortKey={sortKey}
+								index={index}
 							/>
 						);
 					})}

--- a/app/[publicListId]/components/LocalList/index.tsx
+++ b/app/[publicListId]/components/LocalList/index.tsx
@@ -197,7 +197,7 @@ export default function LocalList({ publicListId }: Props) {
 				className={`motion-safe:transition-opacity motion-safe:duration-200 ${isPending ? "opacity-50" : "opacity-100"}`}
 			>
 				<ListContainer>
-					{items.map((movie) => {
+					{items.map((movie, index) => {
 						return (
 							<Item
 								key={movie.listItemId}
@@ -205,6 +205,7 @@ export default function LocalList({ publicListId }: Props) {
 								isLoggedIn={false}
 								publicListId={publicListId}
 								sortKey={sortKey}
+								index={index}
 							/>
 						);
 					})}

--- a/app/components/ListItem/Content/Detail/index.tsx
+++ b/app/components/ListItem/Content/Detail/index.tsx
@@ -1,4 +1,5 @@
 import { formatFullDate } from "@/lib/date";
+import { withTmdbImageSize } from "@/features/movieDatabase/helpers/withTmdbImageSize";
 
 type Props = {
 	title: string;
@@ -34,8 +35,10 @@ export default function MovieDetail({
 						<div className="w-full aspect-square flex justify-center">
 							<img
 								className="object-contain h-full rounded-sm"
-								src={posterImage}
+								src={withTmdbImageSize(posterImage, "w342")}
 								alt=""
+								decoding="async"
+								fetchPriority="high"
 							/>
 						</div>
 					</div>
@@ -70,8 +73,9 @@ export default function MovieDetail({
 			</div>
 			<img
 				className="w-full h-full object-contain rounded-2xl"
-				src={backgroundImage}
+				src={withTmdbImageSize(backgroundImage, "w780")}
 				alt=""
+				decoding="async"
 			/>
 		</div>
 	);

--- a/app/components/MovieInputForm/ExistingItem/Detail/index.tsx
+++ b/app/components/MovieInputForm/ExistingItem/Detail/index.tsx
@@ -1,5 +1,6 @@
 import { formatRelativeDate } from "@/lib/date";
 import type { ListItem } from "@/features/list/types/ListItem";
+import { withTmdbImageSize } from "@/features/movieDatabase/helpers/withTmdbImageSize";
 
 type Props = {
 	movie: ListItem;
@@ -14,16 +15,19 @@ export default function ExistingListItemDetail({ movie }: Props) {
 						<div className="flex justify-center h-full aspect-square py-2">
 							<img
 								className="object-contain h-full rounded-sm"
-								src={movie.details.posterImage}
+								src={withTmdbImageSize(movie.details.posterImage, "w342")}
 								alt=""
+								decoding="async"
+								fetchPriority="high"
 							/>
 						</div>
 					</div>
 					<div className="w-full aspect-video rounded-xl">
 						<img
 							className="w-full h-full object-cover rounded-xl"
-							src={movie.details.backgroundImage}
+							src={withTmdbImageSize(movie.details.backgroundImage, "w780")}
 							alt=""
+							decoding="async"
 						/>
 					</div>
 				</div>

--- a/app/components/SearchResult/index.tsx
+++ b/app/components/SearchResult/index.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence } from "motion/react";
 import type { TmdbSearchResponse } from "@/features/movieDatabase/types/TmdbResponse";
 import { TMDB_IMAGE_BASE_URL } from "@/app/consts";
+import { withTmdbImageSize } from "@/features/movieDatabase/helpers/withTmdbImageSize";
 import { Button } from "@/components/ui/button";
 import ArrowCircleLeftIcon from "@/components/ui/Icons/ArrowCircleLeftIcon";
 import FadeIn from "../ListItem/Content/FadeIn";
@@ -47,7 +48,7 @@ export default function SearchResult({
 				{searchResult ? (
 					<FadeIn key="content">
 						<ul className="flex flex-col gap-4 relative">
-							{searchResult.results.map((result) => (
+							{searchResult.results.map((result, resultIndex) => (
 								<li
 									key={String(result.id)}
 									className="w-full aspect-video bg-background-dark-1 rounded-md"
@@ -56,8 +57,10 @@ export default function SearchResult({
 										<div className="col-start-1 col-end-3 w-full flex items-center">
 											<img
 												className="rounded-md"
-												src={TMDB_IMAGE_BASE_URL + result.poster_path}
+												src={withTmdbImageSize(TMDB_IMAGE_BASE_URL + result.poster_path, "w185")}
 												alt=""
+												decoding="async"
+												{...(resultIndex >= 1 ? { loading: "lazy" } : {})}
 											/>
 										</div>
 										<div className="col-start-3 col-end-8 pl-4 sm:pl-8 sm:py-8 flex flex-col justify-between">
@@ -93,8 +96,10 @@ export default function SearchResult({
 									<div className="w-full aspect-video">
 										<img
 											className="object-contain w-full rounded-md"
-											src={TMDB_IMAGE_BASE_URL + result.backdrop_path}
+											src={withTmdbImageSize(TMDB_IMAGE_BASE_URL + result.backdrop_path, "w300")}
 											alt=""
+											decoding="async"
+											{...(resultIndex >= 1 ? { loading: "lazy" } : {})}
 										/>
 									</div>
 								</li>

--- a/features/movieDatabase/helpers/withTmdbImageSize.ts
+++ b/features/movieDatabase/helpers/withTmdbImageSize.ts
@@ -1,0 +1,27 @@
+/**
+ * TMDB 画像 URL のサイズセグメント（/t/p/{size}/）を別のサイズに置換する。
+ *
+ * 表示用途に応じたサイズを指定することで帯域幅を削減できる。
+ * DB に保存された URL は original サイズ（"https://image.tmdb.org/t/p/original/..."）
+ * のため、表示直前にこのヘルパーで縮小サイズへ変換する。
+ *
+ * - 入力が undefined / 空文字の場合は undefined を返す（呼び出し側で `<img src={...}>` に
+ *   そのまま渡せば src 属性が省略され、空文字 src による再ダウンロード警告を回避できる）
+ * - TMDB 以外の URL（/t/p/ を含まない）の場合はそのまま返す
+ */
+
+export type TmdbImageSize =
+	| "w185"
+	| "w300"
+	| "w342"
+	| "w500"
+	| "w780"
+	| "original";
+
+export function withTmdbImageSize(
+	url: string | undefined,
+	size: TmdbImageSize,
+): string | undefined {
+	if (!url) return undefined;
+	return url.replace(/\/t\/p\/[^/]+\//, `/t/p/${size}/`);
+}

--- a/tests/e2e/pages/list/functional/itemImageFallback.test.ts
+++ b/tests/e2e/pages/list/functional/itemImageFallback.test.ts
@@ -1,0 +1,93 @@
+import crypto from "node:crypto";
+import { expect, test } from "@playwright/test";
+import { seedLocalStorageViaInitScript } from "../../../helpers/localStorageSeed";
+
+test.describe("Item 画像条件付きレンダリング", () => {
+	test("details ありアイテムはカード配下に img が 2 個、details なしアイテムは 0 個", async ({
+		page,
+		browserName,
+	}) => {
+		test.skip(browserName !== "chromium", "DOM 構造検証のため Chromium のみで十分");
+
+		const listId = crypto.randomUUID();
+		const itemA = {
+			listItemId: crypto.randomUUID(),
+			title: "映画A",
+			url: "https://example.com/a",
+			serviceSlug: "unext",
+			serviceName: "U-NEXT",
+			createdAt: "2024-01-01T00:00:00.000Z",
+			isWatched: false,
+			watchedAt: null,
+			details: {
+				movieId: 1,
+				officialTitle: "映画A",
+				backgroundImage: "https://example.com/bg-a.jpg",
+				posterImage: "https://example.com/poster-a.jpg",
+				director: [],
+				runningMinutes: 90,
+				releaseYear: 2023,
+				releaseDate: "2023-06-01",
+				externalDatabaseMovieId: 1,
+				overview: "概要A",
+			},
+		};
+		const itemB = {
+			listItemId: crypto.randomUUID(),
+			title: "映画B",
+			url: "https://example.com/b",
+			serviceSlug: "unext",
+			serviceName: "U-NEXT",
+			createdAt: "2024-03-01T00:00:00.000Z",
+			isWatched: false,
+			watchedAt: null,
+		};
+
+		await seedLocalStorageViaInitScript(page, {
+			list: { listId, items: [itemA, itemB] },
+			subLists: [],
+		});
+		await page.goto(`/${listId}`);
+		await expect(page.locator("h2", { hasText: "映画A" })).toBeVisible();
+
+		const cardA = page.locator(".first", { hasText: "映画A" });
+		const cardB = page.locator(".first", { hasText: "映画B" });
+
+		// 映画A（details あり）: img が 2 個（ポスター + 背景）
+		await expect(cardA.locator("img")).toHaveCount(2);
+
+		// 映画B（details なし）: img が 0 個
+		await expect(cardB.locator("img")).toHaveCount(0);
+	});
+
+	test("details なしアイテムのカードに SearchButton（ポスター画像なし）が表示される", async ({
+		page,
+		browserName,
+	}) => {
+		test.skip(browserName !== "chromium", "DOM 構造検証のため Chromium のみで十分");
+
+		const listId = crypto.randomUUID();
+		const itemB = {
+			listItemId: crypto.randomUUID(),
+			title: "映画B",
+			url: "https://example.com/b",
+			serviceSlug: "unext",
+			serviceName: "U-NEXT",
+			createdAt: "2024-03-01T00:00:00.000Z",
+			isWatched: false,
+			watchedAt: null,
+		};
+
+		await seedLocalStorageViaInitScript(page, {
+			list: { listId, items: [itemB] },
+			subLists: [],
+		});
+		await page.goto(`/${listId}`);
+		await expect(page.locator("h2", { hasText: "映画B" })).toBeVisible();
+
+		const cardB = page.locator(".first", { hasText: "映画B" });
+
+		// SearchButton のフォールバックテキスト「ポスター画像なし」が表示されている
+		await expect(cardB.getByRole("button", { name: "ポスター画像なし" })).toBeVisible();
+	});
+});


### PR DESCRIPTION
Closes #269

## 概要

リスト画面のアイテム画像表示を高速化する。2 段階の最適化を本ブランチで段階的に計測しながら適用した。

- **Step 1**: TMDB 画像 URL のサイズ指定を用途別に置換（表示直前変換、DB 書き込み層は据え置き）
- **Step 2**: `<img>` 属性チューニング（`loading="lazy"` / `decoding="async"` / `fetchpriority="high"`）

副次修正:
- `details` を持たないアイテムでの empty `src` 警告を解消
- 意味のない `<img>` 要素自体を DOM に出さない構造修正

## 計測結果

Issue 作者の方針に従い計測ハーネス（Large テスト）を作成し、3 時点 × 16 ケース × 2 ネットワーク条件 × 5 回中央値で計測した（ハーネスは役目を終えたため最終コミットで削除済み）。

### 帯域削減（bytesTotal の中央値、シナリオ list）

| シナリオ | baseline | Step 1 | Step 2 |
|---|---:|---:|---:|
| list 全条件 | 5,430,144 B | **366,082 B** | 366,082 B |
| detail / auth / mobile / 3G | 5,430,144 B | 366,082 B | **228,454 B** |

→ Step 1 のみで **約 93% の転送量削減**。

### LCP（3G スロットリング下の中央値、単位 ms）

| シナリオ | baseline | Step 1 | Step 2 |
|---|---:|---:|---:|
| list / auth / mobile | 6,040 | **628** | 688 |
| list / guest / mobile | 7,012 | **1,324** | 1,352 |
| list / auth / desktop | 6,072 | **656** | 792 |
| list / guest / desktop | 7,012 | **1,328** | 1,352 |
| detail / auth / mobile | 5,968 | **584** | 672 |
| detail / auth / desktop | 5,880 | **492** | 780 |

→ 3G 条件で **約 90% の LCP 改善**（6 秒台 → 0.6〜1.4 秒）。Step 2 の LCP は Step 1 から微増（誤差範囲〜+290ms）。

### Step 2 の寄与（初回ロード時点のスナップショット）

`networkidle` まで待った最終値では Step 2 の効果が見えないため、`load` イベント時点でスナップショット計測を追加した。

| シナリオ | baseline | Step 1 | Step 2 |
|---|---:|---:|---:|
| list / auth / mobile / `tmdbBytesInitial` | 5,430,144 | 366,082 | **228,454**（▼38%） |
| list / guest / mobile / `tmdbRequestsInitial` | 20 | 20 | **6**（▼70%） |

→ `loading="lazy"` が折り返し外画像の初回ロードを抑制している証拠。

### 計測されなかったケース

- scenarios 3（TMDB 検索結果）/ 4（MovieInputForm プレビュー）は途中で TMDB_API_KEY が消えたため未計測
- list / detail で十分強いシグナルが得られたため再計測は省略

## 実装の補足

### Step 1: 表示直前で URL サイズ変換

`features/movieDatabase/helpers/withTmdbImageSize.ts` を新規作成。DB に保存された `original` URL を変えずに、表示時のみ用途別サイズへ置換する：

| 用途 | 適用サイズ |
|---|---|
| リスト ポスター | w342 |
| リスト 背景 | w300 |
| 詳細 ポスター | w342 |
| 詳細 背景 | w780 |
| TMDB 検索結果 ポスター | w185 |
| TMDB 検索結果 背景 | w300 |
| MovieInputForm プレビュー | w342 / w780 |

DB マイグレーション不要・既存レコードにも即時効く設計。

### Step 2: 属性チューニング

リスト：`index < 3` のポスターに `fetchPriority="high"`、`index >= 3` の画像に `loading="lazy"`、全画像に `decoding="async"`。  
詳細・プレビュー：単一表示なのでポスターに `fetchPriority="high"` + 全画像に `decoding="async"`。  
TMDB 検索結果：折り返し外（`resultIndex >= 1`）に `loading="lazy"`。

### 副次修正

`Item` で `details` がない場合に空 `src` の `<img>` がレンダリングされ、ブラウザの「empty string was passed to the src attribute」警告と無意味な DOM 要素が残っていた。`withTmdbImageSize` の戻り値を `string | undefined` に変更したうえで、`<img>` 自体を条件付きレンダリングに変更。フォールバック UI は既存の「ダーク背景 + SearchButton」をそのまま使用。

## Large テストの扱い

計測のためだけに書いたハーネスで、CI には乗らず（外部 TMDB CDN 依存）、assertion なしの計測専用。中央値を期待値として固定して regression 検知テストに育てる選択肢も検討したが、CI 非対象である以上手動運用が必須で維持コスト > 価値と判断し最終コミットで削除した。

## Test plan

- [x] `npm run lint`
- [x] `npm run test`（179 件）
- [x] `npm run test:e2e tests/e2e/pages/list/functional/itemImageFallback.test.ts`（新規追加分）
- [x] `npm run test:e2e tests/e2e/pages/list/functional/sort.test.ts` / `sublist.test.ts`（リグレッション確認）
- [x] 手動: details ありリスト・詳細・検索結果・プレビューで画像が崩れず表示される
- [x] 手動: details なしアイテムで `<img>` 要素が DOM に出ず、コンソールに empty-src 警告が出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)