### PR TITLE
fix: ゲストの直接URLアクセス時のハイドレーションエラーを解消 (#278)

### DIFF
--- a/app/[publicListId]/components/LocalList/index.tsx
+++ b/app/[publicListId]/components/LocalList/index.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState, useEffect, useRef } from "react";
 import { useAtomValue } from "jotai";
 import { risutopottoAtom } from "@/features/shared/store";
+import { useIsHydrated } from "@/features/shared/hooks/useIsHydrated";
 import {
 	sortItems,
 	type SortKey,
@@ -35,6 +36,8 @@ const INITIAL_SERVICE_FILTER: ServiceFilter = [];
 
 export default function LocalList({ publicListId }: Props) {
 	const store = useAtomValue(risutopottoAtom);
+
+	const isHydrated = useIsHydrated();
 
 	const [sortKey, setSortKey] = useState<SortKey>("createdAt");
 	const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
@@ -121,8 +124,8 @@ export default function LocalList({ publicListId }: Props) {
 		setSortOrder(order);
 	};
 
-	if (!listId) {
-		return;
+	if (!isHydrated || !listId) {
+		return null;
 	}
 
 	return (

--- a/components/Menu/Content/index.tsx
+++ b/components/Menu/Content/index.tsx
@@ -3,6 +3,7 @@
 import { useAtomValue } from "jotai";
 import { usePathname } from "next/navigation";
 import { risutopottoAtom } from "@/features/shared/store";
+import { useIsHydrated } from "@/features/shared/hooks/useIsHydrated";
 import HomeIcon from "../../ui/Icons/HomeIcon";
 import ListIcon from "../../ui/Icons/ListIcon";
 import MenuItem from "../MenuItem";
@@ -15,8 +16,9 @@ type Props = {
 export default function MenuContent({ publicListId }: Props) {
 	const store = useAtomValue(risutopottoAtom);
 	const pathname = usePathname();
+	const isHydrated = useIsHydrated();
 
-	const listId = publicListId ?? store.list.listId;
+	const listId = publicListId ?? (isHydrated ? store.list.listId : "");
 
 	return (
 		<nav className="h-(--navigation-height) fixed bottom-(--navigation-bottom) w-full flex justify-center gap-2">

--- a/features/shared/hooks/useIsHydrated.ts
+++ b/features/shared/hooks/useIsHydrated.ts
@@ -1,0 +1,9 @@
+import { useSyncExternalStore } from "react";
+
+export function useIsHydrated(): boolean {
+	return useSyncExternalStore(
+		() => () => {},
+		() => true,
+		() => false,
+	);
+}

--- a/tests/e2e/pages/list/non-functional/hydration.test.ts
+++ b/tests/e2e/pages/list/non-functional/hydration.test.ts
@@ -1,0 +1,86 @@
+import crypto from "node:crypto";
+import { expect, test } from "@playwright/test";
+import { resetDatabase, seedDatabase } from "../../../lib/dbHelpers";
+import { seedLocalStorageViaInitScript } from "../../../helpers/localStorageSeed";
+
+test.describe("LocalList - ハイドレーションエラーなし", () => {
+	test.beforeEach(async () => {
+		await resetDatabase();
+		await seedDatabase();
+	});
+
+	test.afterEach(async () => {
+		await resetDatabase();
+	});
+
+	test("ゲストとして直接 URL アクセスしたとき React ハイドレーションエラー #418 が発生しない", async ({
+		page,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "desktop-chromium",
+			"このテストは desktop-chromium プロジェクトのみ対象",
+		);
+
+		const pageErrors: string[] = [];
+		page.on("pageerror", (err) => {
+			pageErrors.push(err.message);
+		});
+
+		const listId = crypto.randomUUID();
+		await seedLocalStorageViaInitScript(page, {
+			list: { listId, items: [] },
+			subLists: [],
+		});
+		await page.goto(`/${listId}`);
+
+		// SubListTabBar が表示されていること
+		await expect(page.getByTestId("sublist-tab-bar")).toBeVisible();
+
+		// React ハイドレーションエラー #418 が発生していないこと
+		const has418Error = pageErrors.some((msg) => msg.includes("418"));
+		expect(has418Error, `pageerror に "418" が含まれていた: ${pageErrors.join(", ")}`).toBe(false);
+	});
+
+	test("ゲストとして直接 URL アクセスしたとき Safari でハイドレーションエラーが発生しない", async ({
+		page,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "desktop-webkit",
+			"このテストは desktop-webkit プロジェクトのみ対象",
+		);
+
+		const pageErrors: string[] = [];
+		const consoleErrors: string[] = [];
+		page.on("pageerror", (err) => {
+			pageErrors.push(err.message);
+		});
+		page.on("console", (msg) => {
+			if (msg.type() === "error") consoleErrors.push(msg.text());
+		});
+
+		const listId = crypto.randomUUID();
+		await seedLocalStorageViaInitScript(page, {
+			list: { listId, items: [] },
+			subLists: [],
+		});
+		await page.goto(`/${listId}`);
+
+		// SubListTabBar が表示されていること
+		await expect(page.getByTestId("sublist-tab-bar")).toBeVisible();
+
+		// React ハイドレーションエラー #418 が発生していないこと
+		const has418Error = pageErrors.some((msg) => msg.includes("418"));
+		expect(has418Error, `pageerror に "418" が含まれていた: ${pageErrors.join(", ")}`).toBe(false);
+
+		// Safari 固有のコンソールエラーによるハイドレーションミスマッチが発生していないこと
+		const hasHydrationError = consoleErrors.some(
+			(msg) =>
+				msg.toLowerCase().includes("didn't match") ||
+				msg.toLowerCase().includes("hydration"),
+		);
+		expect(
+			hasHydrationError,
+			`console error にハイドレーションエラーが含まれていた: ${consoleErrors.join(", ")}`,
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- `useSyncExternalStore` ベースの `useIsHydrated` フックを新規作成（`features/shared/hooks/useIsHydrated.ts`）
- `LocalList`：hydrate 前は `null` を返すよう `useIsHydrated` を適用（Chromium の pageerror #418 を解消）
- `MenuContent`：hydrate 前は `listId=""` を維持し `href="/"` のままにすることで属性ミスマッチを解消（Safari の console error を解消）
- E2E テストを追加（`desktop-chromium` で pageerror #418、`desktop-webkit` で console error の両方を検証）

## Background

`risutopottoAtom`（Jotai の `atomWithStorage`）は localStorage を同期的に読む。サーバー描画時は localStorage が存在しないため初期値が使われるが、クライアントの hydrate 時には localStorage の実際の値が使われ、ツリー構造または属性値のミスマッチが発生していた。

`useState + useEffect` の `mounted` パターンは回避策だが、`useSyncExternalStore` の `getServerSnapshot` を使うことで React に「サーバーとクライアントで値が意図的に異なる」ことを正式に伝えられる。Jotai はデータ管理・型推論の担当としてそのまま維持している。

## Test plan

- [x] `npm run test:e2e` で `hydration.test.ts`（desktop-chromium・desktop-webkit）がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)