### PR TITLE
fix: ListItemボタン高さ揃え・サブリストドロワー余白・サブリストメニューはみ出し修正 (#277, #285)

### DIFF
--- a/app/[publicListId]/components/ListController/index.tsx
+++ b/app/[publicListId]/components/ListController/index.tsx
@@ -113,7 +113,7 @@ export default function ListController({
 
 	return (
 		<>
-			<div className="max-w-6xl mx-auto px-4 sm:px-9 py-4">
+			<div className="max-w-6xl w-full mx-auto px-4 sm:px-9 py-4">
 				<search className="w-full px-2 flex items-center rounded-full border border-foreground-dark-3 bg-background transition-[color,box-shadow] focus-within:border-foreground-dark-2 focus-within:ring-foreground-dark-2 focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px]">
 					<SearchIcon
 						className="size-6 text-muted-foreground pointer-events-none text-foreground-dark-3"
@@ -139,7 +139,7 @@ export default function ListController({
 					)}
 				</search>
 
-				<div className="flex items-center gap-1 pt-4 pb-2">
+				<div className="w-full flex justify-between sm:justify-start gap-1 pt-4 pb-2 overflow-scroll">
 					<div className="flex items-center gap-1 rounded-full border border-background-light-1 p-1">
 						<div className="text-xs font-bold text-foreground-dark-1 px-1">
 							<FilterIcon className="size-4" />
@@ -156,25 +156,22 @@ export default function ListController({
 							/>
 						</div>
 					</div>
+					<SortButton
+						activeSortKey={sortKey}
+						activeSortOrder={sortOrder}
+						onSort={handleSort}
+					/>
 
-					<div className="flex gap-1">
-						<SortButton
-							activeSortKey={sortKey}
-							activeSortOrder={sortOrder}
-							onSort={handleSort}
+					{mainListPublicId !== publicListId && (
+						<SubListMoreMenu
+							subListPublicId={publicListId}
+							subListName={
+								subLists.find((sl) => sl.publicId === publicListId)?.name ?? ""
+							}
+							mainListPublicId={mainListPublicId}
+							isLoggedIn={isLoggedIn}
 						/>
-						{mainListPublicId !== publicListId && (
-							<SubListMoreMenu
-								subListPublicId={publicListId}
-								subListName={
-									subLists.find((sl) => sl.publicId === publicListId)?.name ??
-									""
-								}
-								mainListPublicId={mainListPublicId}
-								isLoggedIn={isLoggedIn}
-							/>
-						)}
-					</div>
+					)}
 				</div>
 
 				<ActiveFilterChips

--- a/app/[publicListId]/components/ServiceFilterButton/index.tsx
+++ b/app/[publicListId]/components/ServiceFilterButton/index.tsx
@@ -77,7 +77,7 @@ export default function ServiceFilterButton({
 			<DropdownMenuTrigger asChild>
 				<Button
 					variant="ghost"
-					className="has-[>svg]:px-2 py-1 text-foreground-dark-1 flex items-center gap-1 text-xs cursor-pointer rounded-full hover:bg-background-light-1 h-6"
+					className="has-[>svg]:px-1 py-1 text-foreground-dark-1 flex items-center gap-1 text-xs cursor-pointer rounded-full hover:bg-background-light-1 h-6"
 				>
 					{TRIGGER_LABEL}
 					<ChevronDownIcon className="size-3" aria-hidden="true" />

--- a/app/[publicListId]/components/SortButton/index.tsx
+++ b/app/[publicListId]/components/SortButton/index.tsx
@@ -90,7 +90,7 @@ export default function SortButton({
 				<Button
 					variant="ghost"
 					data-testid="sort-button-trigger"
-					className="has-[>svg]:px-3 py-4 text-foreground-dark-1 flex items-center gap-1 text-xs cursor-pointer hover:bg-background-light-1 rounded-full h-8 border border-background-light-1"
+					className="has-[>svg]:px-3 py-4 text-foreground-dark-1 flex items-center gap-1 text-xs cursor-pointer hover:bg-background-light-1 rounded-full border border-background-light-1"
 				>
 					<SortIcon className="size-4" />
 					{triggerLabel}

--- a/app/[publicListId]/components/SubListMoreMenu/index.tsx
+++ b/app/[publicListId]/components/SubListMoreMenu/index.tsx
@@ -93,8 +93,8 @@ export default function SubListMoreMenu({
 				<DropdownMenuTrigger asChild>
 					<Button
 						aria-label="その他のメニュー"
-						variant="ghost"
-						className="has-[>svg]:px-2 py-3 text-foreground-dark-1 flex items-center gap-1 cursor-pointer hover:bg-background-light-1"
+						variant="outline"
+						className="border-background-light-1 rounded-full has-[>svg]:px-2 py-3 text-foreground-dark-1 flex items-center gap-1 cursor-pointer hover:bg-background-light-1"
 					>
 						<MoreIcon className="size-5" />
 					</Button>

--- a/app/[publicListId]/components/WatchedFilterButton/index.tsx
+++ b/app/[publicListId]/components/WatchedFilterButton/index.tsx
@@ -45,7 +45,7 @@ export default function WatchedFilterButton({ value, onChange }: Props) {
 			<DropdownMenuTrigger asChild>
 				<Button
 					variant="ghost"
-					className="has-[>svg]:px-2 py-3 text-foreground-dark-1 flex items-center gap-1 text-xs cursor-pointer hover:bg-background-light-1 rounded-full h-6"
+					className="has-[>svg]:px-1 py-1 text-foreground-dark-1 flex items-center gap-1 text-xs cursor-pointer hover:bg-background-light-1 rounded-full h-6"
 				>
 					{TRIGGER_LABEL}
 					<ChevronDownIcon className="size-3" aria-hidden="true" />

--- a/app/components/ListItem/Content/SubMenu/index.tsx
+++ b/app/components/ListItem/Content/SubMenu/index.tsx
@@ -109,7 +109,7 @@ export default function SubMenu({
 				<DropdownMenuTrigger asChild>
 					<Button
 						variant="outline"
-						className="h-10.5 aspect-square has-[>svg]:p-0 box-content border-2 border-background-light-1 bg-transparent cursor-pointer text-foreground-dark-1 hover:text-foreground hover:bg-background-light-2"
+						className="size-12 aspect-square has-[>svg]:p-0 border-2 border-background-light-1 bg-transparent cursor-pointer text-foreground-dark-1 hover:text-foreground hover:bg-background-light-2"
 					>
 						<MoreIcon className="size-6" />
 					</Button>

--- a/app/components/ListItem/Content/SubmitButton/index.tsx
+++ b/app/components/ListItem/Content/SubmitButton/index.tsx
@@ -11,7 +11,7 @@ export default function SubmitButton({ isDisabled, onSubmit }: Props) {
 			disabled={isDisabled}
 			onClick={onSubmit}
 			variant={"outline"}
-			className="cursor-pointer flex-1 py-5 border-background-light-2 hover:border-background-light-3 hover:bg-background-light-1"
+			className="h-12 cursor-pointer flex-1 border-2 border-background-light-2 hover:border-background-light-3 hover:bg-background-light-1"
 		>
 			これで登録する
 		</Button>

--- a/app/components/SubListSelectDrawer/SubListSelectDrawerLayout.tsx
+++ b/app/components/SubListSelectDrawer/SubListSelectDrawerLayout.tsx
@@ -57,7 +57,7 @@ export default function SubListSelectDrawerLayout({
 					<DrawerHeader className="items-center pt-2 pb-4">
 						<DrawerTitle className="text-foreground-dark-1 text-xl">サブリストに追加</DrawerTitle>
 					</DrawerHeader>
-					<div className="flex flex-col gap-1 max-w-120">
+					<div className="flex flex-col gap-1 w-full max-w-120">
 						{subLists.map((sl) => (
 							<button
 								key={sl.publicId}


### PR DESCRIPTION
## Summary
- #277: `ListItem` の `SubmitButton`（「これで登録する」）と `SubMenu`（「…」トリガー）の高さを 48px に統一（`SubMenu` 側を `size-12` + `border-box` に変更）
- #285: 「サブリストに追加」ドロワー内のリストコンテナに `w-full` を付与し、幅が縮こまる問題を解消
- リスト画面のコントローラ行が右にはみ出していたサブリストメニューボタンを修正。コントローラ行を `w-full overflow-scroll` にし、`SubListMoreMenu` を outline ボタンに変更して並びを整理。あわせて `SortButton`/`ServiceFilterButton`/`WatchedFilterButton` のパディング・高さも微調整

## Test plan
- [x] `ListItem` の編集状態で「これで登録する」と「…」ボタンの高さが揃って見える
- [x] サブリスト画面で「…」メニューが右にはみ出さず、画面内に収まる
- [x] 「サブリストに追加」ドロワーが想定どおりの幅で表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)