### PR TITLE
fix: リストアイテムからサブリスト新規作成時に作成元アイテムを自動登録 (#284)

### DIFF
--- a/app/[publicListId]/components/List/Item/Detail/index.tsx
+++ b/app/[publicListId]/components/List/Item/Detail/index.tsx
@@ -15,13 +15,13 @@ type SubList = {
 };
 
 type Props = {
-	publicListId: string;
+	mainListPublicId: string;
 	subLists: SubList[];
 	checkedSubListIdsMap: Map<string, string[]>;
 };
 
 export default function ListItemDetail({
-	publicListId,
+	mainListPublicId,
 	subLists,
 	checkedSubListIdsMap,
 }: Props) {
@@ -68,7 +68,7 @@ export default function ListItemDetail({
 							<BottomSheetContent withPadding>
 								<RegisteredListItem
 									movie={movie}
-									publicListId={publicListId}
+									mainListPublicId={mainListPublicId}
 									subLists={subLists}
 									checkedSubListIds={
 										checkedSubListIdsMap?.get(movie.listItemId) ?? []

--- a/app/[publicListId]/components/List/Item/index.tsx
+++ b/app/[publicListId]/components/List/Item/index.tsx
@@ -23,6 +23,7 @@ type LoggedInProps = {
 	movie: ListItem;
 	isLoggedIn: true;
 	publicListId: string;
+	mainListPublicId: string;
 	subLists: SubList[];
 	checkedSubListIds: string[];
 	sortKey?: SortKey;
@@ -33,6 +34,7 @@ type GuestProps = {
 	movie: ListItem;
 	isLoggedIn: false;
 	publicListId: string;
+	mainListPublicId: string;
 	sortKey?: SortKey;
 	index: number;
 };
@@ -61,7 +63,7 @@ const formatDateLabel = (
 };
 
 export default function Item(props: Props) {
-	const { movie, isLoggedIn, publicListId, sortKey, index } = props;
+	const { movie, isLoggedIn, mainListPublicId, sortKey, index } = props;
 	const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
 	const store = useAtomValue(risutopottoAtom);
@@ -92,7 +94,7 @@ export default function Item(props: Props) {
 					isOpen={isDrawerOpen}
 					onClose={() => setIsDrawerOpen(false)}
 					listItemId={movie.listItemId}
-					publicListId={publicListId}
+					mainListPublicId={mainListPublicId}
 					subLists={props.subLists}
 					checkedSubListIds={props.checkedSubListIds}
 				/>
@@ -101,7 +103,7 @@ export default function Item(props: Props) {
 					isOpen={isDrawerOpen}
 					onClose={() => setIsDrawerOpen(false)}
 					listItemId={movie.listItemId}
-					publicListId={publicListId}
+					mainListPublicId={mainListPublicId}
 					subLists={localSubLists}
 					checkedSubListIds={localCheckedSubListIds}
 				/>

--- a/app/[publicListId]/components/List/index.tsx
+++ b/app/[publicListId]/components/List/index.tsx
@@ -44,10 +44,10 @@ export default async function List({ items, publicListId, userId }: Props) {
 				isLoggedIn={true}
 			/>
 			<ListItemDetail
-			publicListId={publicListId}
-			subLists={subLists}
-			checkedSubListIdsMap={checkedSubListIdsMap}
-		/>
+				mainListPublicId={mainListPublicId}
+				subLists={subLists}
+				checkedSubListIdsMap={checkedSubListIdsMap}
+			/>
 		</>
 	);
 }

--- a/app/[publicListId]/components/ListController/index.tsx
+++ b/app/[publicListId]/components/ListController/index.tsx
@@ -197,6 +197,7 @@ export default function ListController({
 									movie={movie}
 									isLoggedIn={true}
 									publicListId={publicListId}
+									mainListPublicId={mainListPublicId}
 									subLists={subLists}
 									checkedSubListIds={checkedSubListIds}
 									sortKey={sortKey}
@@ -210,6 +211,7 @@ export default function ListController({
 								movie={movie}
 								isLoggedIn={false}
 								publicListId={publicListId}
+								mainListPublicId={mainListPublicId}
 								sortKey={sortKey}
 								index={index}
 							/>

--- a/app/[publicListId]/components/LocalList/index.tsx
+++ b/app/[publicListId]/components/LocalList/index.tsx
@@ -77,7 +77,7 @@ export default function LocalList({ publicListId }: Props) {
 				isLoggedIn={false}
 			/>
 			<ListItemDetail
-				publicListId={publicListId}
+				mainListPublicId={listId}
 				subLists={subLists}
 				checkedSubListIdsMap={checkedSubListIdsMap}
 			/>

--- a/app/components/ListItem/Content/SubMenu/index.tsx
+++ b/app/components/ListItem/Content/SubMenu/index.tsx
@@ -43,7 +43,7 @@ type Props = {
 	searchDisabled: boolean;
 	removeDisabled: boolean;
 	listItemId: string;
-	publicListId: string;
+	mainListPublicId: string;
 } & (LoggedInProps | LocalProps);
 
 export default function SubMenu({
@@ -52,7 +52,7 @@ export default function SubMenu({
 	searchDisabled,
 	removeDisabled,
 	listItemId,
-	publicListId,
+	mainListPublicId,
 	isLoggedIn,
 	subLists,
 	checkedSubListIds,
@@ -87,7 +87,7 @@ export default function SubMenu({
 					isOpen={isDrawerOpen}
 					onClose={() => setIsDrawerOpen(false)}
 					listItemId={listItemId}
-					publicListId={publicListId}
+					mainListPublicId={mainListPublicId}
 					subLists={subLists}
 					checkedSubListIds={checkedSubListIds}
 				/>
@@ -96,7 +96,7 @@ export default function SubMenu({
 					isOpen={isDrawerOpen}
 					onClose={() => setIsDrawerOpen(false)}
 					listItemId={listItemId}
-					publicListId={publicListId}
+					mainListPublicId={mainListPublicId}
 					subLists={localSubLists}
 					checkedSubListIds={localCheckedSubListIds}
 				/>

--- a/app/components/ListItem/Editing/index.tsx
+++ b/app/components/ListItem/Editing/index.tsx
@@ -28,7 +28,7 @@ type Props = {
 	handleToggleWatch?: () => void;
 	isTogglePending?: boolean;
 	storeSuccess?: boolean;
-	publicListId?: string;
+	mainListPublicId?: string;
 	errorMessage?: string;
 };
 
@@ -44,7 +44,7 @@ export default function EditingListItem({
 	handleToggleWatch,
 	isTogglePending,
 	storeSuccess,
-	publicListId = "",
+	mainListPublicId = "",
 	errorMessage,
 }: Props) {
 	const auth = useAuth();
@@ -93,7 +93,7 @@ export default function EditingListItem({
 												searchDisabled={isSearchPending}
 												removeDisabled={isRemovePending}
 												listItemId={movie && "listItemId" in movie ? movie.listItemId : ""}
-												publicListId={publicListId}
+												mainListPublicId={mainListPublicId}
 												isLoggedIn={true}
 												subLists={[]}
 												checkedSubListIds={[]}
@@ -105,7 +105,7 @@ export default function EditingListItem({
 												searchDisabled={isSearchPending}
 												removeDisabled={isRemovePending}
 												listItemId={movie && "listItemId" in movie ? movie.listItemId : ""}
-												publicListId={publicListId}
+												mainListPublicId={mainListPublicId}
 												isLoggedIn={false}
 											/>
 										)

--- a/app/components/ListItem/Registered/index.tsx
+++ b/app/components/ListItem/Registered/index.tsx
@@ -29,7 +29,7 @@ type SubList = {
 
 type Props = {
 	movie: ListItem;
-	publicListId: string;
+	mainListPublicId: string;
 	subLists: SubList[];
 	checkedSubListIds: string[];
 	refresh?: () => void;
@@ -37,7 +37,7 @@ type Props = {
 
 export default function RegisteredListItem({
 	movie,
-	publicListId,
+	mainListPublicId,
 	subLists,
 	checkedSubListIds,
 	refresh,
@@ -149,6 +149,7 @@ export default function RegisteredListItem({
 				isTogglePending={isTogglePending}
 				storeSuccess={displaySuccess}
 				errorMessage={displayErrorMessage}
+				mainListPublicId={mainListPublicId}
 			/>
 		);
 	}
@@ -179,7 +180,7 @@ export default function RegisteredListItem({
 			isSearchPending={isSearchExternalMovieDatabasePending}
 			isTogglePending={isTogglePending}
 			optimisticIsWatched={optimisticIsWatched}
-			publicListId={publicListId}
+			mainListPublicId={mainListPublicId}
 			subLists={subLists}
 			checkedSubListIds={checkedSubListIds}
 			handleToggleWatch={() => {

--- a/app/components/ListItem/Watch/WatchListItem.stories.tsx
+++ b/app/components/ListItem/Watch/WatchListItem.stories.tsx
@@ -39,8 +39,7 @@ const meta = {
 		isRemovePending: false,
 		handleSearch: () => {},
 		handleRemove: () => {},
-		publicListId: "story-public-list-id",
-		
+		mainListPublicId: "story-main-list-public-id",
 	},
 	decorators: [
 		(Story) => (

--- a/app/components/ListItem/Watch/index.tsx
+++ b/app/components/ListItem/Watch/index.tsx
@@ -24,7 +24,7 @@ type Props = {
 	handleSearch: () => void;
 	handleRemove: () => void;
 	handleToggleWatch?: () => void;
-	publicListId: string;
+	mainListPublicId: string;
 	subLists?: SubList[];
 	checkedSubListIds?: string[];
 };
@@ -38,7 +38,7 @@ export default function WatchListItem({
 	handleSearch,
 	handleRemove,
 	handleToggleWatch,
-	publicListId,
+	mainListPublicId,
 	subLists,
 	checkedSubListIds,
 }: Props) {
@@ -61,7 +61,7 @@ export default function WatchListItem({
 							searchDisabled={isSearchPending}
 							removeDisabled={isRemovePending}
 							listItemId={"listItemId" in movie ? movie.listItemId : ""}
-							publicListId={publicListId}
+							mainListPublicId={mainListPublicId}
 							isLoggedIn={true}
 							subLists={subLists ?? []}
 							checkedSubListIds={checkedSubListIds ?? []}
@@ -73,7 +73,7 @@ export default function WatchListItem({
 							searchDisabled={isSearchPending}
 							removeDisabled={isRemovePending}
 							listItemId={"listItemId" in movie ? movie.listItemId : ""}
-							publicListId={publicListId}
+							mainListPublicId={mainListPublicId}
 							isLoggedIn={false}
 						/>
 					)

--- a/app/components/SubListCreateModal/index.tsx
+++ b/app/components/SubListCreateModal/index.tsx
@@ -11,47 +11,79 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { createSubList } from "@/features/list/actions/createSubList";
+import { createSubListWithItem } from "@/features/list/actions/createSubListWithItem";
 import { useListLocalStorageRepository } from "@/features/list/hooks/useListLocalStorageRepository";
 
 type Props = {
 	isOpen: boolean;
 	onClose: () => void;
-	publicListId: string;
+	mainListPublicId: string;
 	isLoggedIn: boolean;
+	listItemId?: string;
 };
+
+const ERROR_MESSAGE = "作成できませんでした。時間を置いて再度お試しください。";
 
 export default function SubListCreateModal({
 	isOpen,
 	onClose,
-	publicListId,
+	mainListPublicId,
 	isLoggedIn,
+	listItemId,
 }: Props) {
 	const [name, setName] = useState("");
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [isPending, startTransition] = useTransition();
 	const router = useRouter();
-	const { createSubList: createLocalSubList } = useListLocalStorageRepository();
+	const {
+		createSubList: createLocalSubList,
+		createSubListWithItem: createLocalSubListWithItem,
+	} = useListLocalStorageRepository();
+
+	const handleClose = () => {
+		setErrorMessage(null);
+		setName("");
+		onClose();
+	};
 
 	const handleSubmit = () => {
 		const trimmedName = name.trim();
 		if (!trimmedName) return;
 
+		setErrorMessage(null);
+
 		startTransition(async () => {
 			if (isLoggedIn) {
-				const result = await createSubList({
-					publicListId,
-					name: trimmedName,
-				});
+				const result = listItemId
+					? await createSubListWithItem({
+							publicListId: mainListPublicId,
+							name: trimmedName,
+							listItemPublicId: listItemId,
+						})
+					: await createSubList({
+							publicListId: mainListPublicId,
+							name: trimmedName,
+						});
+
 				if (result.success) {
-					onClose();
 					setName("");
+					setErrorMessage(null);
+					onClose();
 					router.push(`/${result.data.subListPublicId}`);
+					return;
 				}
-			} else {
-				const subListId = createLocalSubList(trimmedName);
-				onClose();
-				setName("");
-				router.push(`/${subListId}`);
+
+				setErrorMessage(ERROR_MESSAGE);
+				return;
 			}
+
+			const subListId = listItemId
+				? createLocalSubListWithItem(trimmedName, listItemId)
+				: createLocalSubList(trimmedName);
+			setName("");
+			setErrorMessage(null);
+			onClose();
+			router.push(`/${subListId}`);
 		});
 	};
 
@@ -59,7 +91,7 @@ export default function SubListCreateModal({
 		<Dialog
 			open={isOpen}
 			onOpenChange={(open) => {
-				if (!open) onClose();
+				if (!open) handleClose();
 			}}
 		>
 			<DialogContent className="border-background-light-2 pb-10">
@@ -76,6 +108,16 @@ export default function SubListCreateModal({
 						className="w-full border border-background-light-2 rounded-md p-2 bg-transparent text-foreground placeholder:text-foreground-dark-2 focus:outline-none focus:border-background-light-2 focus-visible:ring-background-light-3"
 					/>
 				</div>
+				{errorMessage && (
+					<p
+						role="alert"
+						className="pb-2 text-center text-sm text-foreground-dark-1"
+					>
+						<span className="underline underline-offset-4 decoration-4 decoration-red-light-2">
+							{errorMessage}
+						</span>
+					</p>
+				)}
 				<Button
 					disabled={isPending || !name.trim()}
 					onClick={handleSubmit}
@@ -85,7 +127,7 @@ export default function SubListCreateModal({
 				</Button>
 				<Button
 					variant={"outline"}
-					onClick={onClose}
+					onClick={handleClose}
 					className="border-background-light-2 cursor-pointer text-foreground-dark-1 hover:bg-background-light-1 hover:border-background-light-3"
 				>
 					キャンセル

--- a/app/components/SubListSelectDrawer/LocalSubListSelectDrawer.tsx
+++ b/app/components/SubListSelectDrawer/LocalSubListSelectDrawer.tsx
@@ -13,7 +13,7 @@ type Props = {
 	isOpen: boolean;
 	onClose: () => void;
 	listItemId: string;
-	publicListId: string;
+	mainListPublicId: string;
 	subLists: SubList[];
 	checkedSubListIds: string[];
 };
@@ -22,7 +22,7 @@ export default function LocalSubListSelectDrawer({
 	isOpen,
 	onClose,
 	listItemId,
-	publicListId,
+	mainListPublicId,
 	subLists,
 	checkedSubListIds,
 }: Props) {
@@ -42,9 +42,9 @@ export default function LocalSubListSelectDrawer({
 			checkedIds={checkedIds}
 			isPending={isPending}
 			onToggle={handleToggle}
-			onCreateClick={() => {}}
-			publicListId={publicListId}
+			mainListPublicId={mainListPublicId}
 			isLoggedIn={false}
+			listItemId={listItemId}
 		/>
 	);
 }

--- a/app/components/SubListSelectDrawer/SubListSelectDrawer.tsx
+++ b/app/components/SubListSelectDrawer/SubListSelectDrawer.tsx
@@ -14,7 +14,7 @@ type Props = {
 	isOpen: boolean;
 	onClose: () => void;
 	listItemId: string;
-	publicListId: string;
+	mainListPublicId: string;
 	subLists: SubList[];
 	checkedSubListIds: string[];
 };
@@ -23,7 +23,7 @@ export default function SubListSelectDrawer({
 	isOpen,
 	onClose,
 	listItemId,
-	publicListId,
+	mainListPublicId,
 	subLists,
 	checkedSubListIds,
 }: Props) {
@@ -49,9 +49,9 @@ export default function SubListSelectDrawer({
 			checkedIds={checkedIds}
 			isPending={isPending}
 			onToggle={handleToggle}
-			onCreateClick={() => {}}
-			publicListId={publicListId}
+			mainListPublicId={mainListPublicId}
 			isLoggedIn={true}
+			listItemId={listItemId}
 		/>
 	);
 }

--- a/app/components/SubListSelectDrawer/SubListSelectDrawerLayout.tsx
+++ b/app/components/SubListSelectDrawer/SubListSelectDrawerLayout.tsx
@@ -22,9 +22,9 @@ type Props = {
 	checkedIds: Set<string>;
 	isPending: boolean;
 	onToggle: (publicId: string) => void;
-	onCreateClick: () => void;
-	publicListId: string;
+	mainListPublicId: string;
 	isLoggedIn: boolean;
+	listItemId?: string;
 };
 
 export default function SubListSelectDrawerLayout({
@@ -34,14 +34,13 @@ export default function SubListSelectDrawerLayout({
 	checkedIds,
 	isPending,
 	onToggle,
-	onCreateClick,
-	publicListId,
+	mainListPublicId,
 	isLoggedIn,
+	listItemId,
 }: Props) {
 	const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 
 	const handleCreateClick = () => {
-		onCreateClick();
 		setIsCreateModalOpen(true);
 	};
 
@@ -108,8 +107,9 @@ export default function SubListSelectDrawerLayout({
 			<SubListCreateModal
 				isOpen={isCreateModalOpen}
 				onClose={() => setIsCreateModalOpen(false)}
-				publicListId={publicListId}
+				mainListPublicId={mainListPublicId}
 				isLoggedIn={isLoggedIn}
+				listItemId={listItemId}
 			/>
 		</>
 	);

--- a/app/components/SubListTabBar/index.tsx
+++ b/app/components/SubListTabBar/index.tsx
@@ -89,7 +89,7 @@ export default function SubListTabBar({
 			<SubListCreateModal
 				isOpen={isModalOpen}
 				onClose={() => setIsModalOpen(false)}
-				publicListId={mainListPublicId}
+				mainListPublicId={mainListPublicId}
 				isLoggedIn={isLoggedIn}
 			/>
 		</>

--- a/features/list/actions/createSubListWithItem.test.ts
+++ b/features/list/actions/createSubListWithItem.test.ts
@@ -1,0 +1,241 @@
+import crypto from "node:crypto";
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "@/db/client";
+import {
+	listItemsTable,
+	listsTable,
+	streamingServicesTable,
+	subListItemsTable,
+	subListsTable,
+	usersTable,
+} from "@/db/schema";
+import { createSubListWithItem } from "./createSubListWithItem";
+
+const { mockCurrentUserId } = vi.hoisted(() => ({
+	mockCurrentUserId: vi.fn(),
+}));
+
+vi.mock("@/features/shared/actions/currentUserId", () => ({
+	currentUserId: mockCurrentUserId,
+}));
+
+async function findStreamingServiceIdBySlug(slug: "netflix") {
+	const [row] = await db
+		.select({ id: streamingServicesTable.id })
+		.from(streamingServicesTable)
+		.where(eq(streamingServicesTable.slug, slug));
+	if (!row) throw new Error(`${slug} not found`);
+	return row.id;
+}
+
+describe("createSubListWithItem", () => {
+	let userId = 0;
+	let publicListId = "";
+	let listItemPublicId = "";
+	let listIdInternal = 0;
+
+	beforeEach(async () => {
+		await db.delete(subListItemsTable);
+		await db.delete(subListsTable);
+		await db.delete(listItemsTable);
+		await db.delete(listsTable);
+		await db.delete(usersTable);
+
+		const [user] = await db
+			.insert(usersTable)
+			.values({ publicId: "create-sub-list-with-item-user" })
+			.returning({ id: usersTable.id });
+
+		userId = user.id;
+		publicListId = crypto.randomUUID();
+
+		const [list] = await db
+			.insert(listsTable)
+			.values({ publicId: publicListId, userId })
+			.returning({ id: listsTable.id });
+		listIdInternal = list.id;
+
+		const netflixId = await findStreamingServiceIdBySlug("netflix");
+		listItemPublicId = crypto.randomUUID();
+
+		await db.insert(listItemsTable).values({
+			publicId: listItemPublicId,
+			listId: listIdInternal,
+			streamingServiceId: netflixId,
+			watchUrl: "https://www.netflix.com/jp/title/with-item-action",
+			titleOnService: "アクションテスト",
+			createdAt: new Date(),
+		});
+	});
+
+	it("認証済みユーザーはサブリストとアイテムを同時作成できる", async () => {
+		mockCurrentUserId.mockResolvedValue({
+			success: true,
+			data: { userId },
+		});
+
+		const result = await createSubListWithItem({
+			publicListId,
+			name: "お気に入り",
+			listItemPublicId,
+		});
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		expect(result.data.subListPublicId).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+		);
+
+		const subLists = await db.select().from(subListsTable);
+		expect(subLists).toHaveLength(1);
+
+		const subListItems = await db.select().from(subListItemsTable);
+		expect(subListItems).toHaveLength(1);
+	});
+
+	it("未認証ユーザーは UNAUTHORIZED_ERROR を受け取る", async () => {
+		mockCurrentUserId.mockResolvedValue({ success: false });
+
+		const result = await createSubListWithItem({
+			publicListId,
+			name: "お気に入り",
+			listItemPublicId,
+		});
+
+		expect(result).toEqual({
+			success: false,
+			error: {
+				code: "UNAUTHORIZED_ERROR",
+				message: "ログインかユーザー登録をしてください。",
+			},
+		});
+	});
+
+	it("不正な publicListId では VALIDATION_ERROR を返す", async () => {
+		mockCurrentUserId.mockResolvedValue({
+			success: true,
+			data: { userId },
+		});
+
+		const result = await createSubListWithItem({
+			publicListId: "not-a-uuid",
+			name: "お気に入り",
+			listItemPublicId,
+		});
+
+		expect(result).toEqual({
+			success: false,
+			error: {
+				code: "VALIDATION_ERROR",
+				message: "不正なリクエストです。",
+			},
+		});
+	});
+
+	it("不正な listItemPublicId では VALIDATION_ERROR を返す", async () => {
+		mockCurrentUserId.mockResolvedValue({
+			success: true,
+			data: { userId },
+		});
+
+		const result = await createSubListWithItem({
+			publicListId,
+			name: "お気に入り",
+			listItemPublicId: "not-a-uuid",
+		});
+
+		expect(result).toEqual({
+			success: false,
+			error: {
+				code: "VALIDATION_ERROR",
+				message: "不正なリクエストです。",
+			},
+		});
+	});
+
+	it("空の name では VALIDATION_ERROR を返す", async () => {
+		mockCurrentUserId.mockResolvedValue({
+			success: true,
+			data: { userId },
+		});
+
+		const result = await createSubListWithItem({
+			publicListId,
+			name: "",
+			listItemPublicId,
+		});
+
+		expect(result).toEqual({
+			success: false,
+			error: {
+				code: "VALIDATION_ERROR",
+				message: "不正なリクエストです。",
+			},
+		});
+	});
+
+	it("51文字以上の name では VALIDATION_ERROR を返す", async () => {
+		mockCurrentUserId.mockResolvedValue({
+			success: true,
+			data: { userId },
+		});
+
+		const result = await createSubListWithItem({
+			publicListId,
+			name: "あ".repeat(51),
+			listItemPublicId,
+		});
+
+		expect(result).toEqual({
+			success: false,
+			error: {
+				code: "VALIDATION_ERROR",
+				message: "不正なリクエストです。",
+			},
+		});
+	});
+
+	it("他ユーザーのリストに対しては NOT_FOUND_ERROR を返す", async () => {
+		mockCurrentUserId.mockResolvedValue({
+			success: true,
+			data: { userId },
+		});
+
+		const result = await createSubListWithItem({
+			publicListId: crypto.randomUUID(),
+			name: "お気に入り",
+			listItemPublicId,
+		});
+
+		expect(result.success).toBe(false);
+		if (result.success) return;
+		expect(result.error.code).toBe("NOT_FOUND_ERROR");
+
+		const subLists = await db.select().from(subListsTable);
+		expect(subLists).toHaveLength(0);
+	});
+
+	it("存在しない listItemPublicId では NOT_FOUND_ERROR を返す", async () => {
+		mockCurrentUserId.mockResolvedValue({
+			success: true,
+			data: { userId },
+		});
+
+		const result = await createSubListWithItem({
+			publicListId,
+			name: "お気に入り",
+			listItemPublicId: crypto.randomUUID(),
+		});
+
+		expect(result.success).toBe(false);
+		if (result.success) return;
+		expect(result.error.code).toBe("NOT_FOUND_ERROR");
+
+		const subLists = await db.select().from(subListsTable);
+		expect(subLists).toHaveLength(0);
+
+		const subListItems = await db.select().from(subListItemsTable);
+		expect(subListItems).toHaveLength(0);
+	});
+});

--- a/features/list/actions/createSubListWithItem.ts
+++ b/features/list/actions/createSubListWithItem.ts
@@ -1,0 +1,78 @@
+"use server";
+
+import z from "zod";
+import type { Result } from "@/features/shared/types/Result";
+import { currentUserId } from "@/features/shared/actions/currentUserId";
+import { userListIdAndPublicListId } from "../repositories/server/listRepository";
+import { createSubListWithItemService } from "../services/createSubListWithItemService";
+
+const createSubListWithItemSchema = z.object({
+	publicListId: z.uuid(),
+	name: z.string().min(1).max(50),
+	listItemPublicId: z.uuid(),
+});
+
+export async function createSubListWithItem({
+	publicListId,
+	name,
+	listItemPublicId,
+}: {
+	publicListId: string;
+	name: string;
+	listItemPublicId: string;
+}): Promise<Result<{ subListPublicId: string }>> {
+	const parsed = createSubListWithItemSchema.safeParse({
+		publicListId,
+		name,
+		listItemPublicId,
+	});
+
+	if (!parsed.success) {
+		return {
+			success: false,
+			error: {
+				code: "VALIDATION_ERROR",
+				message: "不正なリクエストです。",
+			},
+		};
+	}
+
+	const authResult = await currentUserId();
+
+	if (!authResult.success) {
+		return {
+			success: false,
+			error: {
+				code: "UNAUTHORIZED_ERROR",
+				message: "ログインかユーザー登録をしてください。",
+			},
+		};
+	}
+
+	const list = await userListIdAndPublicListId(authResult.data.userId);
+
+	if (!list || list.publicListId !== parsed.data.publicListId) {
+		return {
+			success: false,
+			error: {
+				code: "NOT_FOUND_ERROR",
+				message: "リストが見つかりませんでした。",
+			},
+		};
+	}
+
+	const serviceResult = await createSubListWithItemService({
+		listId: list.id,
+		name: parsed.data.name,
+		listItemPublicId: parsed.data.listItemPublicId,
+	});
+
+	if (!serviceResult.success) {
+		return serviceResult;
+	}
+
+	return {
+		success: true,
+		data: { subListPublicId: serviceResult.data.publicId },
+	};
+}

--- a/features/list/hooks/useListLocalStorageRepository.ts
+++ b/features/list/hooks/useListLocalStorageRepository.ts
@@ -8,6 +8,7 @@ import {
 	clearLocalList,
 	clearSubLists,
 	createSubList,
+	createSubListWithItem,
 	deleteSubList,
 	getListId,
 	getListItems,
@@ -41,6 +42,8 @@ export function useListLocalStorageRepository() {
 		parseLocalList: () => parseLocalList(store),
 		getSubLists: () => getSubLists(store),
 		createSubList: (name: string) => createSubList(store, name),
+		createSubListWithItem: (name: string, listItemId: string) =>
+			createSubListWithItem(store, name, listItemId),
 		addSubListItem: (subListId: string, listItemId: string) =>
 			addSubListItem(store, subListId, listItemId),
 		removeSubListItem: (subListId: string, listItemId: string) =>

--- a/features/list/repositories/client/listLocalStorageRepository.test.ts
+++ b/features/list/repositories/client/listLocalStorageRepository.test.ts
@@ -13,6 +13,7 @@ import {
 	parseLocalList,
 	getSubLists,
 	createSubList,
+	createSubListWithItem,
 	addSubListItem,
 	removeSubListItem,
 	renameSubList,
@@ -212,6 +213,55 @@ describe("createSubList", () => {
 		const store = setupStore();
 		const subListId = createSubList(store, "テスト", () => "fixed-sub-id");
 		expect(subListId).toBe("fixed-sub-id");
+	});
+});
+
+describe("createSubListWithItem", () => {
+	it("新規サブリストを作成し、初期アイテムが登録された状態になる", () => {
+		const store = setupStore();
+		const subListId = createSubListWithItem(store, "新規", "item-x");
+		const subLists = getSubLists(store);
+		expect(subLists).toHaveLength(1);
+		expect(subLists[0]).toMatchObject({
+			subListId,
+			name: "新規",
+			listItemIds: ["item-x"],
+		});
+	});
+
+	it("1 回の store.set で適用される（subLists が空のまま中間状態が観測されない）", () => {
+		const store = setupStore();
+		const observed: { length: number; itemIds: string[] }[] = [];
+		const unsubscribe = store.sub(risutopottoAtom, () => {
+			const subLists = store.get(risutopottoAtom).subLists;
+			observed.push({
+				length: subLists.length,
+				itemIds: subLists[0]?.listItemIds ?? [],
+			});
+		});
+
+		createSubListWithItem(store, "原子的", "item-y");
+
+		unsubscribe();
+		// 「サブリストを作成しただけで listItemIds が空」という中間状態を観測しないこと
+		const intermediate = observed.find(
+			(snapshot) => snapshot.length === 1 && snapshot.itemIds.length === 0,
+		);
+		expect(intermediate).toBeUndefined();
+		// 最終状態としては listItemIds に item-y が入っている
+		expect(observed.at(-1)).toEqual({ length: 1, itemIds: ["item-y"] });
+	});
+
+	it("generateId を注入した場合はその値が subListId になる", () => {
+		const store = setupStore();
+		const subListId = createSubListWithItem(
+			store,
+			"固定",
+			"item-z",
+			() => "fixed-sub-id",
+		);
+		expect(subListId).toBe("fixed-sub-id");
+		expect(getSubLists(store)[0]?.subListId).toBe("fixed-sub-id");
 	});
 });
 

--- a/features/list/repositories/client/listLocalStorageRepository.ts
+++ b/features/list/repositories/client/listLocalStorageRepository.ts
@@ -125,6 +125,24 @@ export function createSubList(
 	return subListId;
 }
 
+export function createSubListWithItem(
+	store: Store,
+	name: string,
+	listItemId: string,
+	generateId: () => string = () => crypto.randomUUID(),
+): string {
+	const current = store.get(risutopottoAtom);
+	const subListId = generateId();
+	store.set(risutopottoAtom, {
+		...current,
+		subLists: [
+			...current.subLists,
+			{ subListId, name, listItemIds: [listItemId] },
+		],
+	});
+	return subListId;
+}
+
 export function addSubListItem(
 	store: Store,
 	subListId: string,

--- a/features/list/services/createSubListWithItemService.test.ts
+++ b/features/list/services/createSubListWithItemService.test.ts
@@ -1,0 +1,113 @@
+import crypto from "node:crypto";
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+import { db } from "@/db/client";
+import {
+	listItemsTable,
+	listsTable,
+	streamingServicesTable,
+	subListItemsTable,
+	subListsTable,
+	usersTable,
+} from "@/db/schema";
+import { createSubListWithItemService } from "./createSubListWithItemService";
+
+async function findStreamingServiceIdBySlug(slug: "netflix") {
+	const [row] = await db
+		.select({ id: streamingServicesTable.id })
+		.from(streamingServicesTable)
+		.where(eq(streamingServicesTable.slug, slug));
+
+	if (!row) {
+		throw new Error(`streaming_services_table に ${slug} が存在しません`);
+	}
+
+	return row.id;
+}
+
+describe("createSubListWithItemService", () => {
+	let listId = 0;
+	let listItemId = 0;
+	let listItemPublicId = "";
+
+	beforeEach(async () => {
+		await db.delete(subListItemsTable);
+		await db.delete(subListsTable);
+		await db.delete(listItemsTable);
+		await db.delete(listsTable);
+		await db.delete(usersTable);
+
+		const [user] = await db
+			.insert(usersTable)
+			.values({ publicId: "create-sub-list-with-item-service-user" })
+			.returning({ id: usersTable.id });
+
+		const [list] = await db
+			.insert(listsTable)
+			.values({ publicId: crypto.randomUUID(), userId: user.id })
+			.returning({ id: listsTable.id });
+		listId = list.id;
+
+		const netflixId = await findStreamingServiceIdBySlug("netflix");
+		listItemPublicId = crypto.randomUUID();
+
+		const [listItem] = await db
+			.insert(listItemsTable)
+			.values({
+				publicId: listItemPublicId,
+				listId,
+				streamingServiceId: netflixId,
+				watchUrl: "https://www.netflix.com/jp/title/with-item",
+				titleOnService: "サブリスト同時作成テスト",
+				createdAt: new Date(),
+			})
+			.returning({ id: listItemsTable.id });
+		listItemId = listItem.id;
+	});
+
+	it("サブリストを作成しつつ指定アイテムを登録できる", async () => {
+		const result = await createSubListWithItemService({
+			listId,
+			name: "新しいサブリスト",
+			listItemPublicId,
+		});
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+
+		expect(result.data.publicId).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+		);
+
+		const subLists = await db.select().from(subListsTable);
+		expect(subLists).toHaveLength(1);
+		expect(subLists[0]?.publicId).toBe(result.data.publicId);
+
+		const subListItems = await db
+			.select()
+			.from(subListItemsTable)
+			.where(eq(subListItemsTable.subListId, subLists[0].id));
+
+		expect(subListItems).toHaveLength(1);
+		expect(subListItems[0].listItemId).toBe(listItemId);
+	});
+
+	it("存在しない listItemPublicId では NOT_FOUND_ERROR を返し、トランザクションがロールバックされる", async () => {
+		const result = await createSubListWithItemService({
+			listId,
+			name: "失敗するサブリスト",
+			listItemPublicId: crypto.randomUUID(),
+		});
+
+		expect(result.success).toBe(false);
+		if (result.success) return;
+
+		expect(result.error.code).toBe("NOT_FOUND_ERROR");
+
+		const subLists = await db.select().from(subListsTable);
+		expect(subLists).toHaveLength(0);
+
+		const subListItems = await db.select().from(subListItemsTable);
+		expect(subListItems).toHaveLength(0);
+	});
+});

--- a/features/list/services/createSubListWithItemService.ts
+++ b/features/list/services/createSubListWithItemService.ts
@@ -1,0 +1,41 @@
+import { db } from "@/db/client";
+import type { Result } from "@/features/shared/types/Result";
+import {
+	findIntListItemIdByPublicId,
+	insertSubList,
+	insertSubListItem,
+} from "../repositories/server/listRepository";
+
+export const createSubListWithItemService = async ({
+	listId,
+	name,
+	listItemPublicId,
+}: {
+	listId: number;
+	name: string;
+	listItemPublicId: string;
+}): Promise<Result<{ publicId: string }>> => {
+	const listItemId = await findIntListItemIdByPublicId(listItemPublicId);
+
+	if (listItemId === null) {
+		return {
+			success: false,
+			error: {
+				code: "NOT_FOUND_ERROR",
+				message: "リストアイテムが見つかりませんでした。",
+			},
+		};
+	}
+
+	const publicId = crypto.randomUUID();
+
+	await db.transaction(async (tx) => {
+		const subList = await insertSubList(tx, { listId, publicId, name });
+		await insertSubListItem(tx, { subListId: subList.id, listItemId });
+	});
+
+	return {
+		success: true,
+		data: { publicId },
+	};
+};

--- a/tests/e2e/pages/list/functional/sublist.test.ts
+++ b/tests/e2e/pages/list/functional/sublist.test.ts
@@ -1,16 +1,48 @@
 import crypto from "node:crypto";
 import { expect, test } from "@playwright/test";
-import { subListsTable, listsTable } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import {
+	listItemsTable,
+	listsTable,
+	streamingServicesTable,
+	subListItemsTable,
+	subListsTable,
+} from "@/db/schema";
 import { setupAuthenticatedUser } from "../../../helpers/auth";
 import { resetDatabase, seedDatabase } from "../../../lib/dbHelpers";
 import { db } from "../../../lib/testDb";
 import { seedLocalStorageViaInitScript } from "../../../helpers/localStorageSeed";
+
+type LocalListItem = {
+	listItemId: string;
+	title: string;
+	url: string;
+	serviceSlug: string;
+	serviceName: string;
+	createdAt: string;
+	isWatched: boolean;
+	watchedAt: null;
+};
 
 type SubListEntry = {
 	subListId: string;
 	name: string;
 	listItemIds: string[];
 };
+
+function makeLocalItem(overrides?: Partial<LocalListItem>): LocalListItem {
+	return {
+		listItemId: crypto.randomUUID(),
+		title: "テスト映画",
+		url: "https://www.netflix.com/jp/title/80100172",
+		serviceSlug: "netflix",
+		serviceName: "Netflix",
+		createdAt: new Date().toISOString(),
+		isWatched: false,
+		watchedAt: null,
+		...overrides,
+	};
+}
 
 test.describe("SubListTabBar - サブリストタブバー機能テスト", () => {
 	test.beforeEach(async () => {
@@ -158,5 +190,382 @@ test.describe("SubListTabBar - サブリストタブバー機能テスト", () =
 		await expect(
 			page.getByRole("heading", { name: "新しいサブリストを作成" }),
 		).toBeVisible();
+	});
+});
+
+test.describe("Issue #284 - サブリスト新規作成時にアイテム自動登録", () => {
+	test.beforeEach(async () => {
+		await resetDatabase();
+		await seedDatabase();
+	});
+
+	test.afterEach(async () => {
+		await resetDatabase();
+	});
+
+	test("未ログイン/メインリスト: アイテムメニューからサブリスト作成すると遷移先にそのアイテムが表示される", async ({
+		page,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "mobile-webkit",
+			"このテストは mobile-webkit プロジェクトのみ対象",
+		);
+		const listId = crypto.randomUUID();
+		const item = makeLocalItem({ title: "ローカル映画A" });
+		await seedLocalStorageViaInitScript(page, {
+			list: { listId, items: [item] },
+			subLists: [],
+		});
+		await page.goto(`/${listId}`);
+
+		await page.getByRole("button", { name: "ポスター画像なし" }).click();
+		await expect(page.getByRole("button", { name: "視聴済みにする" })).toBeVisible();
+
+		await page.locator('button[data-variant="outline"][aria-haspopup="menu"]:not([aria-label])').click();
+		await page.getByText("サブリストに追加").click();
+		await page.getByRole("button", { name: "新しいサブリストを作成" }).click();
+
+		await expect(page.getByRole("heading", { name: "新しいサブリストを作成" })).toBeVisible();
+		await page.getByPlaceholder("サブリスト名（50文字以内）").fill("お気に入り");
+		await page.getByRole("button", { name: "作成する" }).click();
+
+		await expect(
+			page.getByRole("heading", { name: "新しいサブリストを作成" }),
+		).toBeHidden();
+		await page.waitForURL((url) => url.pathname !== `/${listId}`);
+
+		// 遷移先（新しいサブリスト）でアイテムが表示される
+		await expect(page.getByText("ローカル映画A").first()).toBeVisible();
+
+		// localStorage 検証: 作成されたサブリストの listItemIds に該当 ID が含まれる
+		const stored = await page.evaluate(() => {
+			return localStorage.getItem("risutopotto");
+		});
+		const parsed = stored ? JSON.parse(stored) : null;
+		expect(parsed?.subLists).toHaveLength(1);
+		expect(parsed?.subLists[0]?.name).toBe("お気に入り");
+		expect(parsed?.subLists[0]?.listItemIds).toContain(item.listItemId);
+	});
+
+	test("未ログイン/サブリスト内: 既存サブリスト表示中にメニューから新規サブリスト作成すると遷移先にアイテムが表示される（不具合リグレッション）", async ({
+		page,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "mobile-webkit",
+			"このテストは mobile-webkit プロジェクトのみ対象",
+		);
+		const listId = crypto.randomUUID();
+		const item = makeLocalItem({ title: "サブリスト経由映画" });
+		const existingSubListId = crypto.randomUUID();
+		const subLists: SubListEntry[] = [
+			{
+				subListId: existingSubListId,
+				name: "既存サブリスト",
+				listItemIds: [item.listItemId],
+			},
+		];
+		await seedLocalStorageViaInitScript(page, {
+			list: { listId, items: [item] },
+			subLists,
+		});
+
+		// サブリスト経路で開く
+		await page.goto(`/${existingSubListId}`);
+
+		await page.getByRole("button", { name: "ポスター画像なし" }).click();
+		await expect(page.getByRole("button", { name: "視聴済みにする" })).toBeVisible();
+
+		await page.locator('button[data-variant="outline"][aria-haspopup="menu"]:not([aria-label])').click();
+		await page.getByText("サブリストに追加").click();
+		await page.getByRole("button", { name: "新しいサブリストを作成" }).click();
+
+		await expect(page.getByRole("heading", { name: "新しいサブリストを作成" })).toBeVisible();
+		await page.getByPlaceholder("サブリスト名（50文字以内）").fill("新規サブリスト");
+		await page.getByRole("button", { name: "作成する" }).click();
+
+		await expect(
+			page.getByRole("heading", { name: "新しいサブリストを作成" }),
+		).toBeHidden();
+		await page.waitForURL((url) => url.pathname !== `/${existingSubListId}`);
+
+		// 新しいサブリスト詳細にアイテムが表示される
+		await expect(page.getByText("サブリスト経由映画").first()).toBeVisible();
+
+		const stored = await page.evaluate(() => {
+			return localStorage.getItem("risutopotto");
+		});
+		const parsed = stored ? JSON.parse(stored) : null;
+		const created = parsed?.subLists?.find(
+			(sl: { name: string }) => sl.name === "新規サブリスト",
+		);
+		expect(created?.listItemIds).toContain(item.listItemId);
+	});
+
+	test("ログイン/メインリスト: アイテムメニュー → 新規サブリスト作成 → DB に sub_list_items が作成される", async ({
+		page,
+		context,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "mobile-webkit",
+			"このテストは mobile-webkit プロジェクトのみ対象",
+		);
+		const baseUrl = "http://localhost:3001";
+		const { userId } = await setupAuthenticatedUser(
+			context,
+			"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
+			baseUrl,
+		);
+
+		const [list] = await db
+			.select({ id: listsTable.id, publicId: listsTable.publicId })
+			.from(listsTable)
+			.where(eq(listsTable.userId, userId));
+
+		const [service] = await db
+			.select({ id: streamingServicesTable.id })
+			.from(streamingServicesTable)
+			.limit(1);
+
+		const listItemPublicId = crypto.randomUUID();
+		const [listItem] = await db
+			.insert(listItemsTable)
+			.values({
+				publicId: listItemPublicId,
+				listId: list.id,
+				titleOnService: "ログイン映画A",
+				watchUrl: "https://www.netflix.com/jp/title/80100172",
+				streamingServiceId: service.id,
+				createdAt: new Date(),
+			})
+			.returning({ id: listItemsTable.id });
+
+		await page.goto(`/${list.publicId}`);
+
+		await page.getByRole("button", { name: "ポスター画像なし" }).click();
+		await expect(page.getByRole("button", { name: "視聴済みにする" })).toBeVisible();
+
+		await page.locator('button[data-variant="outline"][aria-haspopup="menu"]:not([aria-label])').click();
+		await page.getByText("サブリストに追加").click();
+		await page.getByRole("button", { name: "新しいサブリストを作成" }).click();
+
+		await page.getByPlaceholder("サブリスト名（50文字以内）").fill("ログインから作成");
+		await page.getByRole("button", { name: "作成する" }).click();
+
+		// 作成モーダルが閉じ、サブリスト詳細へ遷移するのを待つ
+		await expect(
+			page.getByRole("heading", { name: "新しいサブリストを作成" }),
+		).toBeHidden();
+		await page.waitForURL((url) => url.pathname !== `/${list.publicId}`);
+
+		// アイテムが表示される
+		await expect(page.getByText("ログイン映画A").first()).toBeVisible();
+
+		// DB 確認
+		const subLists = await db
+			.select({ id: subListsTable.id, name: subListsTable.name })
+			.from(subListsTable)
+			.where(eq(subListsTable.listId, list.id));
+		expect(subLists).toHaveLength(1);
+		expect(subLists[0].name).toBe("ログインから作成");
+
+		const subListItems = await db
+			.select()
+			.from(subListItemsTable)
+			.where(eq(subListItemsTable.subListId, subLists[0].id));
+		expect(subListItems).toHaveLength(1);
+		expect(subListItems[0].listItemId).toBe(listItem.id);
+	});
+
+	test("ログイン/サブリスト内: 既存サブリスト表示中にメニュー → 新規サブリスト作成 → DB 確認（Issue #284 報告の不具合リグレッション）", async ({
+		page,
+		context,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "mobile-webkit",
+			"このテストは mobile-webkit プロジェクトのみ対象",
+		);
+		const baseUrl = "http://localhost:3001";
+		const { userId } = await setupAuthenticatedUser(
+			context,
+			"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
+			baseUrl,
+		);
+
+		const [list] = await db
+			.select({ id: listsTable.id, publicId: listsTable.publicId })
+			.from(listsTable)
+			.where(eq(listsTable.userId, userId));
+
+		const [service] = await db
+			.select({ id: streamingServicesTable.id })
+			.from(streamingServicesTable)
+			.limit(1);
+
+		const [listItem] = await db
+			.insert(listItemsTable)
+			.values({
+				publicId: crypto.randomUUID(),
+				listId: list.id,
+				titleOnService: "サブリスト経由ログイン映画",
+				watchUrl: "https://www.netflix.com/jp/title/80100172",
+				streamingServiceId: service.id,
+				createdAt: new Date(),
+			})
+			.returning({ id: listItemsTable.id });
+
+		// 既存サブリスト作成
+		const existingSubListPublicId = crypto.randomUUID();
+		const [existingSubList] = await db
+			.insert(subListsTable)
+			.values({
+				publicId: existingSubListPublicId,
+				listId: list.id,
+				name: "既存サブリスト",
+				createdAt: new Date(),
+			})
+			.returning({ id: subListsTable.id });
+
+		// 既存サブリストに紐付け
+		await db.insert(subListItemsTable).values({
+			subListId: existingSubList.id,
+			listItemId: listItem.id,
+		});
+
+		// サブリスト経路で開く
+		await page.goto(`/${existingSubListPublicId}`);
+
+		await page.getByRole("button", { name: "ポスター画像なし" }).click();
+		await expect(page.getByRole("button", { name: "視聴済みにする" })).toBeVisible();
+
+		await page.locator('button[data-variant="outline"][aria-haspopup="menu"]:not([aria-label])').click();
+		await page.getByText("サブリストに追加").click();
+		await page.getByRole("button", { name: "新しいサブリストを作成" }).click();
+
+		await page.getByPlaceholder("サブリスト名（50文字以内）").fill("新規サブリストB");
+		await page.getByRole("button", { name: "作成する" }).click();
+
+		await expect(
+			page.getByRole("heading", { name: "新しいサブリストを作成" }),
+		).toBeHidden();
+		await page.waitForURL((url) => url.pathname !== `/${existingSubListPublicId}`);
+
+		// 遷移先で対象アイテムが表示される
+		await expect(page.getByText("サブリスト経由ログイン映画").first()).toBeVisible();
+
+		// 作成された新しいサブリストに該当アイテムが紐付いている
+		const createdSubLists = await db
+			.select({ id: subListsTable.id, name: subListsTable.name })
+			.from(subListsTable)
+			.where(eq(subListsTable.name, "新規サブリストB"));
+		expect(createdSubLists).toHaveLength(1);
+
+		const createdSubListItems = await db
+			.select()
+			.from(subListItemsTable)
+			.where(eq(subListItemsTable.subListId, createdSubLists[0].id));
+		expect(createdSubListItems).toHaveLength(1);
+		expect(createdSubListItems[0].listItemId).toBe(listItem.id);
+	});
+
+	test("エラー表示: action が失敗するとモーダル内にエラー文言が表示される（ダイアログは閉じない）", async ({
+		page,
+		context,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "mobile-webkit",
+			"このテストは mobile-webkit プロジェクトのみ対象",
+		);
+		const baseUrl = "http://localhost:3001";
+		const { userId } = await setupAuthenticatedUser(
+			context,
+			"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
+			baseUrl,
+		);
+
+		const [list] = await db
+			.select({ id: listsTable.id, publicId: listsTable.publicId })
+			.from(listsTable)
+			.where(eq(listsTable.userId, userId));
+
+		const [service] = await db
+			.select({ id: streamingServicesTable.id })
+			.from(streamingServicesTable)
+			.limit(1);
+
+		const [listItem] = await db
+			.insert(listItemsTable)
+			.values({
+				publicId: crypto.randomUUID(),
+				listId: list.id,
+				titleOnService: "エラー映画",
+				watchUrl: "https://www.netflix.com/jp/title/80100172",
+				streamingServiceId: service.id,
+				createdAt: new Date(),
+			})
+			.returning({ id: listItemsTable.id });
+
+		await page.goto(`/${list.publicId}`);
+
+		await page.getByRole("button", { name: "ポスター画像なし" }).click();
+		await expect(page.getByRole("button", { name: "視聴済みにする" })).toBeVisible();
+
+		await page.locator('button[data-variant="outline"][aria-haspopup="menu"]:not([aria-label])').click();
+		await page.getByText("サブリストに追加").click();
+		await page.getByRole("button", { name: "新しいサブリストを作成" }).click();
+
+		// モーダルを開いた状態で、対象 listItem を DB から削除しておく
+		// → action 送信時に NOT_FOUND_ERROR となりエラー表示される
+		await db.delete(listItemsTable).where(eq(listItemsTable.id, listItem.id));
+
+		await page.getByPlaceholder("サブリスト名（50文字以内）").fill("エラーテスト");
+		await page.getByRole("button", { name: "作成する" }).click();
+
+		// ダイアログは閉じない & エラーメッセージが表示される
+		const errorAlert = page.getByRole("alert");
+		await expect(errorAlert).toBeVisible();
+		await expect(errorAlert).toContainText("作成できませんでした");
+		// 既存スタイル踏襲: underline decoration-red-light-2 が含まれる
+		const underlineSpan = errorAlert.locator("span.underline");
+		await expect(underlineSpan).toHaveClass(/decoration-red-light-2/);
+
+		// ダイアログはまだ開いている
+		await expect(
+			page.getByRole("heading", { name: "新しいサブリストを作成" }),
+		).toBeVisible();
+	});
+
+	test("SubListTabBar 経路の回帰: タブバーの「サブリストを作成」からは新規作成後にアイテム追加なしで遷移する", async ({
+		page,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "mobile-webkit",
+			"このテストは mobile-webkit プロジェクトのみ対象",
+		);
+		const listId = crypto.randomUUID();
+		const item = makeLocalItem({ title: "タブバー回帰映画" });
+		await seedLocalStorageViaInitScript(page, {
+			list: { listId, items: [item] },
+			subLists: [],
+		});
+		await page.goto(`/${listId}`);
+
+		await page.getByRole("button", { name: "サブリストを作成" }).click();
+		await expect(
+			page.getByRole("heading", { name: "新しいサブリストを作成" }),
+		).toBeVisible();
+		await page.getByPlaceholder("サブリスト名（50文字以内）").fill("タブから作成");
+		await page.getByRole("button", { name: "作成する" }).click();
+
+		// 遷移後、新しいサブリストは空（既存アイテムは含まれない）
+		const stored = await page.evaluate(() => {
+			return localStorage.getItem("risutopotto");
+		});
+		const parsed = stored ? JSON.parse(stored) : null;
+		const created = parsed?.subLists?.find(
+			(sl: { name: string }) => sl.name === "タブから作成",
+		);
+		expect(created?.listItemIds).toEqual([]);
+		// 元のメインリスト上のアイテムは無関係に保持されている
+		expect(parsed?.list?.items).toHaveLength(1);
 	});
 });


### PR DESCRIPTION
## 概要

Issue #284 の対応。

- リストアイテムのメニュー「サブリストに追加」→「新しいサブリストを作成」からサブリストを作ったとき、作成元アイテムを登録済みの状態で遷移するようにした
- あわせて、**サブリスト内のアイテムから新規サブリストを作成しようとすると必ず失敗していた不具合**を解消した（`createSubList` action がメインリストの publicId しか受け付けない実装だったため）

## 変更内容

### バックエンド

- `createSubListWithItemService` を新規追加。1 つの `db.transaction` 内でサブリスト作成 → アイテム追加を atomic に実行。アイテムが見つからない場合はサブリストも作成しない
- `createSubListWithItem` action を新規追加（バリデーション / 認証 / 所有権確認 → service 呼び出し）
- `listLocalStorageRepository` に `createSubListWithItem` を追加。1 回の `store.set` でサブリスト作成とアイテム追加を atomic に適用

### フロントエンド

- `SubListCreateModal` の `publicListId` プロップを `mainListPublicId` に変更し、任意の `listItemId` を追加。`listItemId` がある場合は `createSubListWithItem` を、ない場合は従来の `createSubList` を呼び分ける
- 作成失敗時はダイアログを閉じずに汎用エラーメッセージを表示（`underline decoration-red-light-2`）
- `mainListPublicId` を `ListController` → `ListItem` → `SubMenu` → `SubListSelectDrawer*` → `SubListCreateModal` まで伝播
- `SubListSelectDrawerLayout` の `onCreateClick: () => {}` 空実装を撤去し、`listItemId` を `SubListCreateModal` へ直接渡す構造に変更

### テスト

- ログイン・ローカル × メインリスト・サブリスト内の 4 ケースで「作成元アイテムがサブリストに登録されている」を E2E 検証
- `SubListTabBar` 経路（アイテム文脈なし）の回帰確認テストを追加

## 注意点

- `SubListTabBar` 経路はプロップ名追従のみで挙動は据え置き（`listItemId` を渡さないため従来どおり作成→遷移のみ）
- 既存の `createSubList` / `addSubListItem` action は変更なし

Closes #284