### PR TITLE
fix(#312): セキュリティ指摘の網羅対応（IDOR / ヘッダ / レート制限 / 依存）

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,17 @@
+name: Audit
+
+on:
+  pull_request:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: 脆弱性監査（本番依存の HIGH 以上のみ）
+        run: npm audit --audit-level=high --omit=dev

--- a/.github/workflows/wf-migration.yaml
+++ b/.github/workflows/wf-migration.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: latest
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -30,23 +30,35 @@ Next.js / Turso / Vercel のフルスタックな構成になっています。
 
 ### 環境変数
 
-`.env`と`.env.test`を使います。
+Next.js の規約に従い、ローカル開発では `.env`、テスト実行では `.env.test` を読み込みます。
 
-#### `.env`
+- `.env` — `.gitignore` 済み。各自で作成する
+- `.env.test` — リポジトリにコミット済み。`npm run test` / `npm run test:e2e` で自動的に読み込まれる
 
-| 変数名 | 用途 | 内容 |
-| --- | --- | --- |
-| RESEND_API_KEY | 認証時のメール送信 | [Resend](https://resend.com/)で発行 |
-| TMDB_API_KEY | 詳細な映画情報の取得 | [TMDB](https://www.themoviedb.org/?language=ja)で発行 |
-| TURSO_DATABASE_URL | アプリケーションが接続するデータベースの指定 | `file:local.db` |
-| JWT_SECRET | セッションごとに発行されるトークンの検証 | ランダム文字列を指定 or `openssl rand -hex 64`などで作成
+> ⚠️ `.env.test` はテスト専用の値（ローカル SQLite ＋ ダミー API キー）です。リポジトリ公開済みのため、**`.env` や本番（Vercel など）で同じ値を流用してはいけません**。特に `JWT_SECRET` / `ENCRYPTION_KEY` / `HMAC_SECRET` は環境ごとに必ず別の値を設定してください。
 
-#### `.env.test`
+#### `.env`（ローカル開発用）
 
 | 変数名 | 用途 | 内容 |
 | --- | --- | --- |
-| TURSO_DATABASE_URL | アプリケーションが接続するデータベースの指定 | `file:local.test.db` |
-| JWT_SECRET | セッションごとに発行されるトークンの検証 | ランダム文字列を指定 or `openssl rand -hex 64`などで作成
+| `TURSO_DATABASE_URL` | 接続先 DB の指定 | `file:local.db` |
+| `RESEND_API_KEY` | 認証メール送信 | [Resend](https://resend.com/) で発行 |
+| `TMDB_API_KEY` | 映画情報の取得 | [TMDB](https://www.themoviedb.org/?language=ja) で発行 |
+| `JWT_SECRET` | セッショントークン署名 | `openssl rand -hex 64` |
+| `ENCRYPTION_KEY` | メールアドレス暗号化（AES-256-GCM） | `openssl rand -hex 32` |
+| `HMAC_SECRET` | メールアドレスの HMAC インデックス | `openssl rand -hex 32` |
+| `COOKIE_SECURE` | Cookie の Secure 属性 | 既定 `true`。ローカルで `http` を使う場合のみ `false` |
+
+#### `.env.test`（テスト実行用）
+
+リポジトリにコミット済みのため、クローン後そのままテストが動きます。値はテスト専用で、外部サービスには接続しません。
+
+| 変数名 | 値 | 備考 |
+| --- | --- | --- |
+| `TURSO_DATABASE_URL` | `file:local.test.db` | ローカル SQLite |
+| `RESEND_API_KEY` | `re_test_dummy` | ダミー値（実際には送信されない） |
+| `COOKIE_SECURE` | `false` | HTTP のテストサーバー向け |
+| `JWT_SECRET` / `ENCRYPTION_KEY` / `HMAC_SECRET` | テスト用ランダム値 | 本番・ローカル開発と必ず異なる値で固定 |
 
 ### リポジトリをクローン
 

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -213,6 +213,7 @@ export const tempSessionTokensTable = sqliteTable("temp_session_tokens_table", {
 export const loginAttemptsTable = sqliteTable("login_attempts_table", {
 	id: int().primaryKey({ autoIncrement: true }),
 	ipAddressHmac: text("ip_address_hmac").notNull(),
+	targetHmac: text("target_hmac").notNull(),
 	attemptType: text("attempt_type")
 		.$type<"code_verify" | "code_send">()
 		.notNull(),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,6 +47,55 @@ type Result<T> = { success: true; data: T } | { success: false; error: AppError 
 
 レート制限は `login_attempts` テーブルで管理。
 
+## 認可
+
+更新系 Action（mutation）は **Service 層で所有権を照合する**。Action 層で代用してはいけない（Service が単独で安全に呼び出せる状態を保つため）。
+
+### 規約
+
+- **Action 層**: `currentUserId()` で userId を取得し、Service に渡す。未認証なら `UNAUTHORIZED_ERROR` を返す。
+- **Service 層**: 操作対象リソースの所有者と `userId` を照合する。
+  - リソース不在 → `NOT_FOUND_ERROR`
+  - 他人のリソース → `FORBIDDEN_ERROR`
+
+### スケルトン
+
+```typescript
+// actions/updateHoge.ts
+export async function updateHoge(args: Args): Promise<Result<Hoge>> {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { success: false, error: { code: "VALIDATION_ERROR", message: "..." } };
+  }
+
+  const authResult = await currentUserId();
+  if (!authResult.success) {
+    return { success: false, error: { code: "UNAUTHORIZED_ERROR", message: "..." } };
+  }
+
+  return await updateHogeService({ ...args, userId: authResult.data.userId });
+}
+
+// services/updateHogeService.ts
+export async function updateHogeService({
+  publicId,
+  userId,
+  ...
+}: Args): Promise<Result<Hoge>> {
+  const resource = await findResourceByPublicId(publicId);
+  if (resource === null) {
+    return { success: false, error: { code: "NOT_FOUND_ERROR", message: "..." } };
+  }
+  if (resource.ownerId !== userId) {
+    return { success: false, error: { code: "FORBIDDEN_ERROR", message: "..." } };
+  }
+
+  // ビジネスロジック
+}
+```
+
+参照系（read）も同様に Service 層で所有権を照合する。
+
 ## データベース
 
 - スキーマ: `db/schema.ts`

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,143 @@
+# CI / デプロイワークフロー
+
+## 設計方針
+
+このリポジトリの CI は「ローカルで実行される検査の重複」ではなく、**デプロイ前提条件のゲート** と **協働者間で結果を共有する報告手段** を役割とする。
+
+### 検査の責任分界
+
+| 検査 | ローカル | CI | 理由 |
+| --- | --- | --- | --- |
+| lint (biome) | ✓ | ✗ | `npm run lint` は `--write` の自動修正モード。CI で走らせても差分が失われ意味がない。CLAUDE.md でローカル実行を必須として明文化 |
+| 型チェック (tsc) | ✓ | ✗ | 同上 |
+| 単体テスト (vitest) | ✓ | ✓ | ローカルでも走るが、結果を PR 上で共有するため CI でも実行 |
+| E2E (Playwright) | ✓ | ✗ | 実行時間が長く、Vercel preview deployment の手動 QA で代替 |
+| build | ✗ | ✓ (Vercel) | Vercel deploy で実質的に検証 |
+| 依存脆弱性 (npm audit) | ✗ | ✓ | 後述 |
+| マイグレーション動作 | ✗ | ✓ (deploy 前) | Turso に対して実マイグレーション |
+
+このプロジェクトは個人開発で、コードの大半は AI エージェント（主に Claude）が書く。Claude は CLAUDE.md の指示に従い `npm run lint && npm run test` をローカルで必ず実行するため、コード変更時点で lint / 型 / テストは通っている前提が成立する。CI が「最後の網」となるのは人間が手書きで CLAUDE.md を読まなかった場合だけで、頻度・コストを勘案して CI からは外している。
+
+## ワークフロー一覧
+
+### test.yml — PR テスト
+
+- トリガー: `pull_request`
+- Vitest 実行 + JUnit reporter で PR に結果掲載
+
+### audit.yml — 脆弱性監査
+
+- トリガー: `pull_request`
+- `npm audit --audit-level=high --omit=dev` を test と並列で実行
+- 詳細は後述
+
+### wf-migration.yaml — Turso マイグレーション（再利用 workflow）
+
+- preview / production それぞれから呼び出される
+- `concurrency` で同時実行を直列化（`cancel-in-progress: false` で実行中のマイグレーションはキャンセルしない）
+
+### on-preview.yaml — Vercel preview deploy
+
+- トリガー: `push`（`main` と `dependabot/**` を除く）
+- Migrate-Preview → Deploy-Preview の順
+- `dependabot/**` を除外する理由: dependabot PR は手動 QA を行わずマージする運用で、preview を消費する利益が薄い
+
+### on-deployment.yaml — Vercel production deploy
+
+- トリガー: `push` to `main`
+- Migrate-Production → Deploy-Production の順
+
+## 脆弱性監査の方針
+
+### なぜ並列ジョブか
+
+`npm audit` は `package-lock.json` だけを入力に取り、テスト結果と意味的に独立する。直列にする必然性がなく、並列実行することで両方の signal が独立して同時に届く。テストが落ちている PR でも audit 結果は見えるためデバッグの観点でも有利。
+
+### スコープ
+
+- `--audit-level=high`: HIGH 以上のみをブロック対象にする
+- `--omit=dev`: dev 専用パッケージ（`@react-email/preview-server`、`drizzle-kit` 等）の脆弱性は対象外
+- moderate 以下は dependabot の定期更新に委ねる
+
+### 巻き込み対策
+
+スコープを絞ることで、新規 CVE 公開で無関係 PR が赤くなる事態を最小化している。それでも HIGH の本番影響が出れば、対処せず merge はさせない (`continue-on-error` は付けない)。
+
+### dependabot との関係
+
+dependabot は daily で `npm-dependencies` グループとして全パッケージを 1 PR にまとめている。audit gate と組み合わさると次のように機能する。
+
+- 通常: dependabot が次回サイクルで脆弱パッケージをバンプ
+- 緊急: 別の PR が来た場合、audit gate がブロックして気付く契機になる
+
+## マイグレーション運用方針
+
+### 原則: ダウンタイム不可
+
+CI の構成上、`wf-migration.yaml`（Turso へのマイグレーション適用）が完了した後に Vercel deploy が走る。この間の数十秒〜数分は **新スキーマ × 旧コード** が同居する。
+
+旧コードの書き込みが新スキーマの制約に引っかかると、その時間内のユーザー操作（特に auth 系）がエラーになる。ログインコード送信や検証が失敗するのはユーザーのリトライコストが大きく許容できない。
+
+したがってマイグレーションは **旧コードでも書き込みが成功する形** で書く。
+
+### 後方互換マイグレーションの書き方
+
+新規 NOT NULL カラム追加、列の rename / drop などはそのままだと旧コードの INSERT を壊す。以下のいずれかの方法で安全に進める。
+
+#### A. DEFAULT 付き NOT NULL（単一 PR で完結）
+
+旧コードが値を書かなくても DEFAULT が当たって INSERT が成功する。
+
+```sql
+ALTER TABLE foo ADD COLUMN bar TEXT NOT NULL DEFAULT '';
+```
+
+新コードは明示的に値を書く。`getRecentAttemptsByTarget` のような検索系は `bar = hmac(real_value)` で検索するため、DEFAULT の空文字レコードはヒットしない。
+
+必要なら後続 PR で `ALTER ... DROP DEFAULT` してセンチネルを取り除く（任意）。
+
+#### B. expand-and-contract（二段階）
+
+教科書的なゼロダウンタイム手法。スキーマの最終形を綺麗に保ちたい場合に使う。
+
+**Phase 1 (expand) — 本 PR**
+
+```sql
+ALTER TABLE foo ADD COLUMN bar TEXT; -- nullable
+```
+
+- 同 PR で新コードを「常に `bar` を書く」形に更新
+- 旧コードは `bar` を書かないが、nullable なので INSERT は成功
+- このフェーズが本番デプロイ完了するまで待つ
+
+**Phase 2 (backfill)**
+
+- 既存の NULL 行を埋める（rate-limit テーブルのような ephemeral データなら省略可）
+
+**Phase 3 (contract) — 次の PR**
+
+```sql
+ALTER TABLE foo ALTER COLUMN bar SET NOT NULL;
+```
+
+- このときには全コードが `bar` を書く状態なので落ちない
+
+#### 列の rename / drop も同様
+
+- expand: 新列を追加し dual-write
+- backfill: 旧列のデータを新列にコピー
+- contract: 旧列を drop
+
+### どちらを選ぶか
+
+| 観点 | A. DEFAULT 付き | B. expand-and-contract |
+| --- | --- | --- |
+| PR 数 | 1 | 2 |
+| 最終スキーマの綺麗さ | 軽くセンチネルが残る | 綺麗 |
+| 二度のリリース調整 | 不要 | 必要 |
+
+特別な事情がなければ **A** が小回りが効く。スキーマ設計上 DEFAULT を許容したくない、または rename / drop のように DEFAULT で逃げられないケースは **B** を使う。
+
+### 例外: 未リリース時
+
+サービスがまだ公開されていない時期は、デプロイ中の auth エラーが誰にも届かないため、後方非互換なマイグレーションでも実害がない。マイグレーション `0039` はこの例外に該当する（本ドキュメント執筆時点で listpot は未リリース）。リリース後はこの例外は無効になる。

--- a/features/auth/actions/issueReauthToken.ts
+++ b/features/auth/actions/issueReauthToken.ts
@@ -2,6 +2,7 @@
 
 import { cookies, headers } from "next/headers";
 import type { Result } from "@/features/shared/types/Result";
+import { getClientIp } from "@/features/shared/lib/getClientIp";
 import { loginCodeSchema } from "../schemas/loginSchemas";
 import { checkRateLimitService } from "../services/checkRateLimitService";
 import { issueReauthTokenService } from "../services/issueReauthTokenService";
@@ -57,13 +58,12 @@ export async function issueReauthToken(
 	}
 
 	const headersList = await headers();
-	const ipAddress =
-		headersList.get("x-forwarded-for")?.split(",")[0] ||
-		headersList.get("x-real-ip") ||
-		"unknown";
+	const ipAddress = getClientIp(headersList);
+	const target = String(verifiedSession.data.userId);
 
 	const { limit } = await checkRateLimitService({
 		ipAddress,
+		target,
 		attemptType: "code_verify",
 		now,
 	});
@@ -85,6 +85,7 @@ export async function issueReauthToken(
 		loginCode: parsed.data.value,
 		userId: verifiedSession.data.userId,
 		ipAddress,
+		target,
 		now,
 	});
 

--- a/features/auth/actions/login.test.ts
+++ b/features/auth/actions/login.test.ts
@@ -19,17 +19,19 @@ const { mockSetCookie, mockCookies, mockHeaders } = vi.hoisted(() => {
 	const cookies = vi.fn(async () => ({
 		set: setCookie,
 	}));
-	const headers = vi.fn(async () => ({
-		get: (name: string) => {
-			if (name === "x-forwarded-for") {
-				return "127.0.0.1";
-			}
-			if (name === "user-agent") {
-				return "vitest-agent";
-			}
-			return null;
-		},
-	}));
+	const headers = vi.fn(
+		async (): Promise<{ get: (name: string) => string | null }> => ({
+			get: (name: string): string | null => {
+				if (name === "x-vercel-forwarded-for") {
+					return "127.0.0.1";
+				}
+				if (name === "user-agent") {
+					return "vitest-agent";
+				}
+				return null;
+			},
+		}),
+	);
 
 	return {
 		mockSetCookie: setCookie,

--- a/features/auth/actions/login.ts
+++ b/features/auth/actions/login.ts
@@ -3,6 +3,7 @@
 import { headers, cookies } from "next/headers";
 import crypto from "node:crypto";
 import type { Result } from "@/features/shared/types/Result";
+import { getClientIp } from "@/features/shared/lib/getClientIp";
 import { loginCodeSchema } from "../schemas/loginSchemas";
 import { checkRateLimitService } from "../services/checkRateLimitService";
 import { loginService } from "../services/loginService";
@@ -29,12 +30,15 @@ export async function login(
 	}
 
 	const headersList = await headers();
+	const ipAddress = getClientIp(headersList);
+	// login は loginCode のみを受け取り email が事前にわからないため
+	// target を ipAddress と同値にして IP 軸のみで保護する。
+	// IP 抽出は getClientIp が信頼ヘッダから取るため偽装は不可。
+	const target = ipAddress;
 
-	const { limit, ipAddress } = await checkRateLimitService({
-		ipAddress:
-			headersList.get("x-forwarded-for")?.split(",")[0] ||
-			headersList.get("x-real-ip") ||
-			"unknown",
+	const { limit } = await checkRateLimitService({
+		ipAddress,
+		target,
 		attemptType: "code_verify",
 		now,
 	});
@@ -63,6 +67,7 @@ export async function login(
 		loginCode: parsed.data.value,
 		deviceId,
 		ipAddress,
+		target,
 		now,
 	});
 

--- a/features/auth/actions/sendCurrentUserLoginCode.ts
+++ b/features/auth/actions/sendCurrentUserLoginCode.ts
@@ -3,6 +3,7 @@
 import { headers } from "next/headers";
 import type { Result } from "@/features/shared/types/Result";
 import { currentUserEmail } from "@/features/shared/actions/currentUserEmail";
+import { getClientIp } from "@/features/shared/lib/getClientIp";
 import { checkRateLimitService } from "../services/checkRateLimitService";
 import { sendLoginCodeService } from "../services/sendLoginCodeService";
 
@@ -21,13 +22,12 @@ export async function sendCurrentUserLoginCode(): Promise<Result> {
 	}
 
 	const headersList = await headers();
-	const ipAddress =
-		headersList.get("x-forwarded-for")?.split(",")[0] ||
-		headersList.get("x-real-ip") ||
-		"unknown";
+	const ipAddress = getClientIp(headersList);
+	const target = emailResult.data.email;
 
 	const { limit } = await checkRateLimitService({
 		ipAddress,
+		target,
 		attemptType: "code_send",
 		now,
 	});
@@ -48,6 +48,7 @@ export async function sendCurrentUserLoginCode(): Promise<Result> {
 	return await sendLoginCodeService({
 		email: emailResult.data.email,
 		ipAddress,
+		target,
 		now,
 	});
 }

--- a/features/auth/actions/sendLoginCode.test.ts
+++ b/features/auth/actions/sendLoginCode.test.ts
@@ -19,14 +19,16 @@ const {
 	mockLoginMailTemplate,
 	mockResendConstructor,
 } = vi.hoisted(() => {
-	const headers = vi.fn(async () => ({
-		get: (name: string) => {
-			if (name === "x-forwarded-for") {
-				return "127.0.0.1";
-			}
-			return null;
-		},
-	}));
+	const headers = vi.fn(
+		async (): Promise<{ get: (name: string) => string | null }> => ({
+			get: (name: string): string | null => {
+				if (name === "x-vercel-forwarded-for") {
+					return "127.0.0.1";
+				}
+				return null;
+			},
+		}),
+	);
 	const sendEmail = vi.fn(async () => ({
 		data: { id: "mock-email-id" },
 		error: null,
@@ -221,6 +223,89 @@ describe("sendLoginCode", () => {
 
 		expect(attempt.attemptType).toBe("code_send");
 		expect(attempt.success).toBe(true);
+	});
+
+	// Issue #312 MEDIUM: x-forwarded-for 偽装によるレート制限回避が塞がれていることの確認。
+	// Vercel エッジが付与する信頼ヘッダ (x-vercel-forwarded-for) のみを参照するため、
+	// 攻撃者が x-forwarded-for を毎回書き換えても IP 軸の集計は変わらず上限で拒否されるべき。
+	it("【x-forwarded-for 偽装耐性】信頼ヘッダ同一なら x-forwarded-for を毎回変えても上限で拒否される", async () => {
+		const targetEmail = "rate-limit-xff-spoof@example.com";
+
+		function mockOnceWithSpoofedXff(spoofed: string) {
+			mockHeaders.mockImplementationOnce(
+				async (): Promise<{ get: (name: string) => string | null }> => ({
+					get: (name: string): string | null => {
+						if (name === "x-vercel-forwarded-for") return "198.51.100.1";
+						if (name === "x-forwarded-for") return spoofed;
+						return null;
+					},
+				}),
+			);
+		}
+
+		for (let i = 0; i < 5; i++) {
+			mockOnceWithSpoofedXff(`203.0.113.${i + 1}`);
+			const result = await sendLoginCode(targetEmail);
+			expect(result).toEqual({ success: true });
+		}
+
+		mockOnceWithSpoofedXff("203.0.113.99");
+		const result = await sendLoginCode(targetEmail);
+
+		expect(result.success).toBe(false);
+		if (result.success) {
+			throw new Error("x-forwarded-for 偽装でレート制限が回避された");
+		}
+		expect(result.error.code).toBe("TOO_MANY_REQUESTS_ERROR");
+	});
+
+	// Issue #312 MEDIUM: 信頼ヘッダ自体が変わるケース（攻撃者がボットネット等で実 IP を多数持つ場合）の防御確認。
+	// target (メール) 軸の集計があるため、IP がバラバラでも同一メール宛は上限で拒否されるべき。
+	it("【IP 回転耐性】信頼ヘッダ上で異なる IP からでも同一メール宛は上限で拒否される", async () => {
+		const targetEmail = "rate-limit-target-axis@example.com";
+
+		function mockOnceWithRealIp(ip: string) {
+			mockHeaders.mockImplementationOnce(
+				async (): Promise<{ get: (name: string) => string | null }> => ({
+					get: (name: string): string | null => {
+						if (name === "x-vercel-forwarded-for") return ip;
+						return null;
+					},
+				}),
+			);
+		}
+
+		for (let i = 0; i < 5; i++) {
+			mockOnceWithRealIp(`198.51.100.${i + 1}`);
+			const result = await sendLoginCode(targetEmail);
+			expect(result).toEqual({ success: true });
+		}
+
+		mockOnceWithRealIp("198.51.100.99");
+		const result = await sendLoginCode(targetEmail);
+
+		expect(result.success).toBe(false);
+		if (result.success) {
+			throw new Error("target 軸のレート制限が機能していない");
+		}
+		expect(result.error.code).toBe("TOO_MANY_REQUESTS_ERROR");
+	});
+
+	// IP 軸保全の確認: 攻撃者が同一 IP から多数のメールを試行するケース。
+	it("【IP 軸保全】同一 IP から異なるメール宛に 5 回送ったあと 6 回目は別メール宛でも拒否される", async () => {
+		// default mockHeaders は x-vercel-forwarded-for=127.0.0.1 を返すため同一 IP として扱われる
+		for (let i = 0; i < 5; i++) {
+			const result = await sendLoginCode(`ip-axis-${i}@example.com`);
+			expect(result).toEqual({ success: true });
+		}
+
+		const result = await sendLoginCode("ip-axis-final@example.com");
+
+		expect(result.success).toBe(false);
+		if (result.success) {
+			throw new Error("IP 軸のレート制限が機能していない");
+		}
+		expect(result.error.code).toBe("TOO_MANY_REQUESTS_ERROR");
 	});
 
 	it("DBには同一メールアドレスの認証コードが常に最新の一件のみ登録される", async () => {

--- a/features/auth/actions/sendLoginCode.ts
+++ b/features/auth/actions/sendLoginCode.ts
@@ -3,6 +3,7 @@
 import z from "zod";
 import { headers } from "next/headers";
 import type { Result } from "@/features/shared/types/Result";
+import { getClientIp } from "@/features/shared/lib/getClientIp";
 import { checkRateLimitService } from "../services/checkRateLimitService";
 import { sendLoginCodeService } from "../services/sendLoginCodeService";
 
@@ -26,12 +27,12 @@ export async function sendLoginCode(email: string): Promise<Result> {
 	}
 
 	const headersList = await headers();
+	const ipAddress = getClientIp(headersList);
+	const target = parsed.data.email;
 
-	const { limit, ipAddress } = await checkRateLimitService({
-		ipAddress:
-			headersList.get("x-forwarded-for")?.split(",")[0] ||
-			headersList.get("x-real-ip") ||
-			"unknown",
+	const { limit } = await checkRateLimitService({
+		ipAddress,
+		target,
 		attemptType: "code_send",
 		now,
 	});
@@ -53,6 +54,7 @@ export async function sendLoginCode(email: string): Promise<Result> {
 	return await sendLoginCodeService({
 		email: parsed.data.email,
 		ipAddress,
+		target,
 		now,
 	});
 }

--- a/features/auth/repositories/attemptRepository.ts
+++ b/features/auth/repositories/attemptRepository.ts
@@ -4,7 +4,7 @@ import { and, eq, gt } from "drizzle-orm";
 import { loginAttemptsTable } from "@/db/schema";
 import { computeHmac } from "@/features/shared/lib/encryption";
 
-export async function getRecentAttempts(
+export async function getRecentAttemptsByIp(
 	ipAddress: string,
 	attemptType: "code_verify" | "code_send",
 	windowStart: Date,
@@ -21,14 +21,33 @@ export async function getRecentAttempts(
 		);
 }
 
+export async function getRecentAttemptsByTarget(
+	target: string,
+	attemptType: "code_verify" | "code_send",
+	windowStart: Date,
+) {
+	return await db
+		.select()
+		.from(loginAttemptsTable)
+		.where(
+			and(
+				eq(loginAttemptsTable.targetHmac, computeHmac(target)),
+				eq(loginAttemptsTable.attemptType, attemptType),
+				gt(loginAttemptsTable.attemptedAt, windowStart),
+			),
+		);
+}
+
 export async function insertAttempt({
 	tx,
 	ipAddress,
+	target,
 	attemptType,
 	success,
 }: {
 	tx?: Tx;
 	ipAddress: string;
+	target: string;
 	attemptType: "code_verify" | "code_send";
 	success: boolean;
 }): Promise<void> {
@@ -36,6 +55,7 @@ export async function insertAttempt({
 
 	await executor.insert(loginAttemptsTable).values({
 		ipAddressHmac: computeHmac(ipAddress),
+		targetHmac: computeHmac(target),
 		attemptType,
 		attemptedAt: new Date(),
 		success,

--- a/features/auth/services/checkRateLimitService.ts
+++ b/features/auth/services/checkRateLimitService.ts
@@ -1,11 +1,16 @@
-import { getRecentAttempts } from "../repositories/attemptRepository";
+import {
+	getRecentAttemptsByIp,
+	getRecentAttemptsByTarget,
+} from "../repositories/attemptRepository";
 
 export async function checkRateLimitService({
 	ipAddress,
+	target,
 	attemptType,
 	now,
 }: {
 	ipAddress: string;
+	target: string;
 	attemptType: "code_verify" | "code_send";
 	now: Date;
 }): Promise<{
@@ -15,35 +20,70 @@ export async function checkRateLimitService({
 		retryAfter?: Date;
 	};
 	ipAddress: string;
+	target: string;
 }> {
 	const windowStart = new Date(now.getTime() - 15 * 60 * 1000); // 15分
-	const attempts = await getRecentAttempts(ipAddress, attemptType, windowStart);
+	const [ipAttempts, targetAttempts] = await Promise.all([
+		getRecentAttemptsByIp(ipAddress, attemptType, windowStart),
+		getRecentAttemptsByTarget(target, attemptType, windowStart),
+	]);
 
 	const maxAttempts = attemptType === "code_verify" ? 10 : 5;
 
-	if (attempts.length >= maxAttempts) {
-		const oldestAttempt = attempts.sort(
-			(a, b) => a.attemptedAt.getTime() - b.attemptedAt.getTime(),
-		)[0];
+	const ipExceeded = ipAttempts.length >= maxAttempts;
+	const targetExceeded = targetAttempts.length >= maxAttempts;
 
-		const retryAfter = new Date(
-			oldestAttempt.attemptedAt.getTime() + 15 * 60 * 1000,
-		);
+	if (ipExceeded || targetExceeded) {
+		const retryAfter = computeRetryAfter({
+			ipExceeded,
+			targetExceeded,
+			ipAttempts,
+			targetAttempts,
+		});
 
 		return {
-			limit: {
-				allowed: false,
-				retryAfter,
-			},
+			limit: { allowed: false, retryAfter },
 			ipAddress,
+			target,
 		};
 	}
 
+	const remainingAttempts =
+		maxAttempts - Math.max(ipAttempts.length, targetAttempts.length);
+
 	return {
-		limit: {
-			allowed: true,
-			remainingAttempts: maxAttempts - attempts.length,
-		},
+		limit: { allowed: true, remainingAttempts },
 		ipAddress,
+		target,
 	};
+}
+
+function computeRetryAfter({
+	ipExceeded,
+	targetExceeded,
+	ipAttempts,
+	targetAttempts,
+}: {
+	ipExceeded: boolean;
+	targetExceeded: boolean;
+	ipAttempts: { attemptedAt: Date }[];
+	targetAttempts: { attemptedAt: Date }[];
+}): Date {
+	const candidates: Date[] = [];
+	if (ipExceeded) {
+		candidates.push(oldestAttemptedAt(ipAttempts));
+	}
+	if (targetExceeded) {
+		candidates.push(oldestAttemptedAt(targetAttempts));
+	}
+	// 両軸とも上限を超えている場合は両方解除されるまで待つので oldest の遅い方
+	const latest = candidates.reduce((acc, d) => (d > acc ? d : acc));
+	return new Date(latest.getTime() + 15 * 60 * 1000);
+}
+
+function oldestAttemptedAt(attempts: { attemptedAt: Date }[]): Date {
+	return attempts.reduce(
+		(acc, a) => (a.attemptedAt < acc ? a.attemptedAt : acc),
+		attempts[0].attemptedAt,
+	);
 }

--- a/features/auth/services/issueReauthTokenService.ts
+++ b/features/auth/services/issueReauthTokenService.ts
@@ -13,11 +13,13 @@ export async function issueReauthTokenService({
 	loginCode,
 	userId,
 	ipAddress,
+	target,
 	now,
 }: {
 	loginCode: string;
 	userId: number;
 	ipAddress: string;
+	target: string;
 	now: Date;
 }): Promise<Result<{ token: string; expiresAt: Date }>> {
 	try {
@@ -36,6 +38,7 @@ export async function issueReauthTokenService({
 					await insertAttempt({
 						tx,
 						ipAddress,
+						target,
 						attemptType: "code_verify",
 						success: false,
 					});
@@ -55,6 +58,7 @@ export async function issueReauthTokenService({
 					await insertAttempt({
 						tx,
 						ipAddress,
+						target,
 						attemptType: "code_verify",
 						success: false,
 					});
@@ -71,6 +75,7 @@ export async function issueReauthTokenService({
 				await insertAttempt({
 					tx,
 					ipAddress,
+					target,
 					attemptType: "code_verify",
 					success: true,
 				});

--- a/features/auth/services/loginService.ts
+++ b/features/auth/services/loginService.ts
@@ -17,11 +17,13 @@ import { decrypt } from "@/features/shared/lib/encryption";
 export async function loginService({
 	loginCode,
 	ipAddress,
+	target,
 	deviceId,
 	now,
 }: {
 	loginCode: string;
 	ipAddress: string;
+	target: string;
 	deviceId: string;
 	now: Date;
 }): Promise<
@@ -57,6 +59,7 @@ export async function loginService({
 					await insertAttempt({
 						tx,
 						ipAddress,
+						target,
 						attemptType: "code_verify",
 						success: false,
 					});
@@ -74,6 +77,7 @@ export async function loginService({
 				await insertAttempt({
 					tx,
 					ipAddress,
+					target,
 					attemptType: "code_verify",
 					success: true,
 				});

--- a/features/auth/services/sendLoginCodeService.ts
+++ b/features/auth/services/sendLoginCodeService.ts
@@ -14,10 +14,12 @@ import { PRO_DOMAIN } from "@/app/consts";
 export async function sendLoginCodeService({
 	email,
 	ipAddress,
+	target,
 	now,
 }: {
 	email: string;
 	ipAddress: string;
+	target: string;
 	now: Date;
 }): Promise<Result> {
 	if (!process.env.RESEND_API_KEY) {
@@ -60,6 +62,7 @@ export async function sendLoginCodeService({
 			await deleteLoginCode({ emailHmac });
 			await insertAttempt({
 				ipAddress,
+				target,
 				attemptType: "code_send",
 				success: false,
 			});
@@ -77,6 +80,7 @@ export async function sendLoginCodeService({
 
 		await insertAttempt({
 			ipAddress,
+			target,
 			attemptType: "code_send",
 			success: true,
 		});

--- a/features/list/actions/addSubListItem.test.ts
+++ b/features/list/actions/addSubListItem.test.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "@/db/client";
 import {
 	listItemsTable,
@@ -11,6 +11,14 @@ import {
 } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { addSubListItem } from "./addSubListItem";
+
+const { mockCurrentUserId } = vi.hoisted(() => ({
+	mockCurrentUserId: vi.fn(),
+}));
+
+vi.mock("@/features/shared/actions/currentUserId", () => ({
+	currentUserId: mockCurrentUserId,
+}));
 
 async function findStreamingServiceIdBySlug(slug: "netflix") {
 	const [row] = await db
@@ -25,6 +33,7 @@ describe("addSubListItem", () => {
 	let subListPublicId = "";
 	let listItemPublicId = "";
 	let subListId = 0;
+	let ownerUserId = 0;
 
 	beforeEach(async () => {
 		await db.delete(listItemsTable);
@@ -35,6 +44,8 @@ describe("addSubListItem", () => {
 			.insert(usersTable)
 			.values({ publicId: "add-sub-list-item-user" })
 			.returning({ id: usersTable.id });
+
+		ownerUserId = user.id;
 
 		const [list] = await db
 			.insert(listsTable)
@@ -71,6 +82,11 @@ describe("addSubListItem", () => {
 
 		// listItem.id を参照するが使用しない（型のため）
 		void listItem;
+
+		mockCurrentUserId.mockResolvedValue({
+			success: true,
+			data: { userId: ownerUserId },
+		});
 	});
 
 	it("アイテムをサブリストへ追加できる", async () => {
@@ -115,6 +131,65 @@ describe("addSubListItem", () => {
 				code: "NOT_FOUND_ERROR",
 				message: "サブリストが見つかりませんでした。",
 			},
+		});
+	});
+
+	describe("所有権チェック（IDOR対策）", () => {
+		it("未認証ユーザーはサブリストへ追加できずUNAUTHORIZED_ERRORを返す", async () => {
+			mockCurrentUserId.mockResolvedValue({
+				success: false,
+				error: { code: "UNAUTHORIZED_ERROR", message: "ログインしていません。" },
+			});
+
+			const result = await addSubListItem({
+				subListPublicId,
+				listItemPublicId,
+			});
+
+			expect(result.success).toBe(false);
+			if (result.success) {
+				return;
+			}
+			expect(result.error.code).toBe("UNAUTHORIZED_ERROR");
+
+			const items = await db
+				.select()
+				.from(subListItemsTable)
+				.where(eq(subListItemsTable.subListId, subListId));
+			expect(items).toHaveLength(0);
+		});
+
+		it("他人のサブリストへは追加できずFORBIDDEN_ERRORを返す", async () => {
+			const [attacker] = await db
+				.insert(usersTable)
+				.values({ publicId: "add-sub-list-item-attacker-user" })
+				.returning({ id: usersTable.id });
+			await db.insert(listsTable).values({
+				publicId: crypto.randomUUID(),
+				userId: attacker.id,
+			});
+
+			mockCurrentUserId.mockResolvedValue({
+				success: true,
+				data: { userId: attacker.id },
+			});
+
+			const result = await addSubListItem({
+				subListPublicId,
+				listItemPublicId,
+			});
+
+			expect(result.success).toBe(false);
+			if (result.success) {
+				return;
+			}
+			expect(result.error.code).toBe("FORBIDDEN_ERROR");
+
+			const items = await db
+				.select()
+				.from(subListItemsTable)
+				.where(eq(subListItemsTable.subListId, subListId));
+			expect(items).toHaveLength(0);
 		});
 	});
 });

--- a/features/list/actions/addSubListItem.ts
+++ b/features/list/actions/addSubListItem.ts
@@ -1,8 +1,8 @@
 "use server";
 
 import z from "zod";
+import { currentUserId } from "@/features/shared/actions/currentUserId";
 import type { Result } from "@/features/shared/types/Result";
-import { findSubListIdByPublicId } from "../repositories/server/listRepository";
 import { manageSubListItemService } from "../services/manageSubListItemService";
 
 const addSubListItemSchema = z.object({
@@ -32,21 +32,22 @@ export async function addSubListItem({
 		};
 	}
 
-	const subListId = await findSubListIdByPublicId(parsed.data.subListPublicId);
+	const authResult = await currentUserId();
 
-	if (!subListId) {
+	if (!authResult.success) {
 		return {
 			success: false,
 			error: {
-				code: "NOT_FOUND_ERROR",
-				message: "サブリストが見つかりませんでした。",
+				code: "UNAUTHORIZED_ERROR",
+				message: "ログインかユーザー登録をしてください。",
 			},
 		};
 	}
 
 	return await manageSubListItemService({
-		subListId,
+		subListPublicId: parsed.data.subListPublicId,
 		listItemPublicId: parsed.data.listItemPublicId,
+		userId: authResult.data.userId,
 		action: "add",
 	});
 }

--- a/features/list/actions/removeListItem.test.ts
+++ b/features/list/actions/removeListItem.test.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import { eq } from "drizzle-orm";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "@/db/client";
 import {
 	listItemsTable,
@@ -12,9 +12,18 @@ import {
 import { computeHmac, encrypt } from "@/features/shared/lib/encryption";
 import { removeListItem } from "./removeListItem";
 
+const { mockCurrentUserId } = vi.hoisted(() => ({
+	mockCurrentUserId: vi.fn(),
+}));
+
+vi.mock("@/features/shared/actions/currentUserId", () => ({
+	currentUserId: mockCurrentUserId,
+}));
+
 describe("removeListItem", () => {
 	let testListId: number;
 	let testStreamingServiceId: number;
+	let ownerUserId: number;
 
 	beforeEach(async () => {
 		const [user] = await db
@@ -43,8 +52,14 @@ describe("removeListItem", () => {
 			throw Error("streaming_services_table に netflix が存在しません");
 		}
 
+		ownerUserId = user.id;
 		testListId = list.id;
 		testStreamingServiceId = streamingService.id;
+
+		mockCurrentUserId.mockResolvedValue({
+			success: true,
+			data: { userId: ownerUserId },
+		});
 	});
 
 	it("リスト内作品を削除できる", async () => {
@@ -91,5 +106,76 @@ describe("removeListItem", () => {
 		expect(result.error.message).toBe(
 			"作品がリストへ登録されていないか、すでに削除されています。",
 		);
+	});
+
+	describe("所有権チェック（IDOR対策）", () => {
+		let victimListItemPublicId: string;
+
+		beforeEach(async () => {
+			victimListItemPublicId = crypto.randomUUID();
+			await db.insert(listItemsTable).values({
+				publicId: victimListItemPublicId,
+				listId: testListId,
+				streamingServiceId: testStreamingServiceId,
+				watchUrl: "https://www.netflix.com/jp/title/80100172",
+				titleOnService: "被害者の映画",
+				createdAt: new Date(),
+			});
+		});
+
+		it("未認証ユーザーは作品を削除できずUNAUTHORIZED_ERRORを返す", async () => {
+			mockCurrentUserId.mockResolvedValue({
+				success: false,
+				error: { code: "UNAUTHORIZED_ERROR", message: "ログインしていません。" },
+			});
+
+			const result = await removeListItem({
+				listItemId: victimListItemPublicId,
+			});
+
+			expect(result.success).toBe(false);
+			if (result.success) {
+				return;
+			}
+			expect(result.error.code).toBe("UNAUTHORIZED_ERROR");
+
+			const records = await db
+				.select({ id: listItemsTable.id })
+				.from(listItemsTable)
+				.where(eq(listItemsTable.publicId, victimListItemPublicId));
+			expect(records).toHaveLength(1);
+		});
+
+		it("他人の作品は削除できずFORBIDDEN_ERRORを返す", async () => {
+			const [attacker] = await db
+				.insert(usersTable)
+				.values({ publicId: "remove-list-item-attacker-user" })
+				.returning({ id: usersTable.id });
+			await db.insert(listsTable).values({
+				publicId: crypto.randomUUID(),
+				userId: attacker.id,
+			});
+
+			mockCurrentUserId.mockResolvedValue({
+				success: true,
+				data: { userId: attacker.id },
+			});
+
+			const result = await removeListItem({
+				listItemId: victimListItemPublicId,
+			});
+
+			expect(result.success).toBe(false);
+			if (result.success) {
+				return;
+			}
+			expect(result.error.code).toBe("FORBIDDEN_ERROR");
+
+			const records = await db
+				.select({ id: listItemsTable.id })
+				.from(listItemsTable)
+				.where(eq(listItemsTable.publicId, victimListItemPublicId));
+			expect(records).toHaveLength(1);
+		});
 	});
 });

--- a/features/list/actions/removeListItem.ts
+++ b/features/list/actions/removeListItem.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import z from "zod";
+import { currentUserId } from "@/features/shared/actions/currentUserId";
 import type { Result } from "@/features/shared/types/Result";
 import { removeListItemService } from "../services/removeListItemService";
 
@@ -26,5 +27,20 @@ export async function removeListItem({ listItemId }: Args): Promise<Result> {
 		};
 	}
 
-	return await removeListItemService({ listItemId: parsed.data.listItemId });
+	const authResult = await currentUserId();
+
+	if (!authResult.success) {
+		return {
+			success: false,
+			error: {
+				code: "UNAUTHORIZED_ERROR",
+				message: "ログインかユーザー登録をしてください。",
+			},
+		};
+	}
+
+	return await removeListItemService({
+		listItemId: parsed.data.listItemId,
+		userId: authResult.data.userId,
+	});
 }

--- a/features/list/actions/removeSubListItem.test.ts
+++ b/features/list/actions/removeSubListItem.test.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "@/db/client";
 import {
 	listItemsTable,
@@ -11,6 +11,14 @@ import {
 } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { removeSubListItem } from "./removeSubListItem";
+
+const { mockCurrentUserId } = vi.hoisted(() => ({
+	mockCurrentUserId: vi.fn(),
+}));
+
+vi.mock("@/features/shared/actions/currentUserId", () => ({
+	currentUserId: mockCurrentUserId,
+}));
 
 async function findStreamingServiceIdBySlug(slug: "netflix") {
 	const [row] = await db
@@ -26,6 +34,7 @@ describe("removeSubListItem", () => {
 	let listItemPublicId = "";
 	let subListId = 0;
 	let listItemId = 0;
+	let ownerUserId = 0;
 
 	beforeEach(async () => {
 		await db.delete(listItemsTable);
@@ -36,6 +45,8 @@ describe("removeSubListItem", () => {
 			.insert(usersTable)
 			.values({ publicId: "remove-sub-list-item-user" })
 			.returning({ id: usersTable.id });
+
+		ownerUserId = user.id;
 
 		const [list] = await db
 			.insert(listsTable)
@@ -75,6 +86,11 @@ describe("removeSubListItem", () => {
 		await db
 			.insert(subListItemsTable)
 			.values({ subListId, listItemId });
+
+		mockCurrentUserId.mockResolvedValue({
+			success: true,
+			data: { userId: ownerUserId },
+		});
 	});
 
 	it("サブリストからアイテムを削除できる", async () => {
@@ -119,6 +135,65 @@ describe("removeSubListItem", () => {
 				code: "NOT_FOUND_ERROR",
 				message: "サブリストが見つかりませんでした。",
 			},
+		});
+	});
+
+	describe("所有権チェック（IDOR対策）", () => {
+		it("未認証ユーザーはサブリストから削除できずUNAUTHORIZED_ERRORを返す", async () => {
+			mockCurrentUserId.mockResolvedValue({
+				success: false,
+				error: { code: "UNAUTHORIZED_ERROR", message: "ログインしていません。" },
+			});
+
+			const result = await removeSubListItem({
+				subListPublicId,
+				listItemPublicId,
+			});
+
+			expect(result.success).toBe(false);
+			if (result.success) {
+				return;
+			}
+			expect(result.error.code).toBe("UNAUTHORIZED_ERROR");
+
+			const items = await db
+				.select()
+				.from(subListItemsTable)
+				.where(eq(subListItemsTable.subListId, subListId));
+			expect(items).toHaveLength(1);
+		});
+
+		it("他人のサブリストからは削除できずFORBIDDEN_ERRORを返す", async () => {
+			const [attacker] = await db
+				.insert(usersTable)
+				.values({ publicId: "remove-sub-list-item-attacker-user" })
+				.returning({ id: usersTable.id });
+			await db.insert(listsTable).values({
+				publicId: crypto.randomUUID(),
+				userId: attacker.id,
+			});
+
+			mockCurrentUserId.mockResolvedValue({
+				success: true,
+				data: { userId: attacker.id },
+			});
+
+			const result = await removeSubListItem({
+				subListPublicId,
+				listItemPublicId,
+			});
+
+			expect(result.success).toBe(false);
+			if (result.success) {
+				return;
+			}
+			expect(result.error.code).toBe("FORBIDDEN_ERROR");
+
+			const items = await db
+				.select()
+				.from(subListItemsTable)
+				.where(eq(subListItemsTable.subListId, subListId));
+			expect(items).toHaveLength(1);
 		});
 	});
 });

--- a/features/list/actions/removeSubListItem.ts
+++ b/features/list/actions/removeSubListItem.ts
@@ -1,8 +1,8 @@
 "use server";
 
 import z from "zod";
+import { currentUserId } from "@/features/shared/actions/currentUserId";
 import type { Result } from "@/features/shared/types/Result";
-import { findSubListIdByPublicId } from "../repositories/server/listRepository";
 import { manageSubListItemService } from "../services/manageSubListItemService";
 
 const removeSubListItemSchema = z.object({
@@ -32,21 +32,22 @@ export async function removeSubListItem({
 		};
 	}
 
-	const subListId = await findSubListIdByPublicId(parsed.data.subListPublicId);
+	const authResult = await currentUserId();
 
-	if (!subListId) {
+	if (!authResult.success) {
 		return {
 			success: false,
 			error: {
-				code: "NOT_FOUND_ERROR",
-				message: "サブリストが見つかりませんでした。",
+				code: "UNAUTHORIZED_ERROR",
+				message: "ログインかユーザー登録をしてください。",
 			},
 		};
 	}
 
 	return await manageSubListItemService({
-		subListId,
+		subListPublicId: parsed.data.subListPublicId,
 		listItemPublicId: parsed.data.listItemPublicId,
+		userId: authResult.data.userId,
 		action: "remove",
 	});
 }

--- a/features/list/actions/renameSubList.test.ts
+++ b/features/list/actions/renameSubList.test.ts
@@ -149,6 +149,29 @@ describe("renameSubList", () => {
 		});
 	});
 
+	it("51文字以上の名称は受け付けない", async () => {
+		mockCurrentUserId.mockResolvedValue({ success: true, data: { userId } });
+
+		const result = await renameSubList({
+			subListPublicId,
+			name: "あ".repeat(51),
+		});
+
+		expect(result).toEqual({
+			success: false,
+			error: {
+				code: "VALIDATION_ERROR",
+				message: "不正なリクエストです。",
+			},
+		});
+
+		const [subList] = await db
+			.select({ name: subListsTable.name })
+			.from(subListsTable)
+			.where(eq(subListsTable.id, subListId));
+		expect(subList?.name).toBe("変更前の名前");
+	});
+
 	it("存在しない subListPublicId は名称変更できない", async () => {
 		mockCurrentUserId.mockResolvedValue({ success: true, data: { userId } });
 

--- a/features/list/actions/renameSubList.ts
+++ b/features/list/actions/renameSubList.ts
@@ -8,7 +8,7 @@ import { renameSubListService } from "../services/renameSubListService";
 
 const renameSubListSchema = z.object({
 	subListPublicId: z.uuid(),
-	name: z.string().min(1),
+	name: z.string().min(1).max(50),
 });
 
 export async function renameSubList({

--- a/features/list/actions/storeListItem.test.ts
+++ b/features/list/actions/storeListItem.test.ts
@@ -1,7 +1,15 @@
 import crypto from "node:crypto";
 import { and, eq } from "drizzle-orm";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "@/db/client";
+
+const { mockCurrentUserId } = vi.hoisted(() => ({
+	mockCurrentUserId: vi.fn(),
+}));
+
+vi.mock("@/features/shared/actions/currentUserId", () => ({
+	currentUserId: mockCurrentUserId,
+}));
 import {
 	directorCacheTable,
 	directorsTable,
@@ -288,6 +296,7 @@ async function assertMovieDirectorRecord({
 describe("storeMovie", () => {
 	let testListId: number;
 	let testPublicListId: string;
+	let ownerUserId: number;
 
 	beforeEach(async () => {
 		const [user] = await db
@@ -306,8 +315,14 @@ describe("storeMovie", () => {
 			.insert(listsTable)
 			.values({ publicId: crypto.randomUUID(), userId: user.id })
 			.returning();
+		ownerUserId = user.id;
 		testListId = list.id;
 		testPublicListId = list.publicId;
+
+		mockCurrentUserId.mockResolvedValue({
+			success: true,
+			data: { userId: ownerUserId },
+		});
 	});
 
 	it("配信作品の情報をリストへ新規登録できる", async () => {
@@ -659,5 +674,146 @@ describe("storeMovie", () => {
 		expect(storedListItems).toHaveLength(0);
 		await assertMoviesTableHasNoRecords();
 		await assertDirectorsTableHasNoRecords();
+	});
+
+	describe("URLスキーム制限（XSS対策）", () => {
+		const buildMovieWithUrl = (url: string): ListItem => ({
+			listItemId: crypto.randomUUID(),
+			title: "スキームテスト映画",
+			url,
+			serviceSlug: "netflix",
+			serviceName: "Netflix",
+			createdAt: new Date(),
+			isWatched: false,
+			watchedAt: null,
+		});
+
+		async function assertNotStored() {
+			const storedListItems = await db
+				.select({ id: listItemsTable.id })
+				.from(listItemsTable)
+				.where(eq(listItemsTable.listId, testListId));
+			expect(storedListItems).toHaveLength(0);
+		}
+
+		it("javascript: スキームのURLは登録できずVALIDATION_ERRORを返す", async () => {
+			const result = await storeListItem({
+				publicListId: testPublicListId,
+				movie: buildMovieWithUrl("javascript:alert(1)"),
+			});
+
+			expect(result).toEqual({
+				success: false,
+				error: {
+					code: "VALIDATION_ERROR",
+					message: "不正なリクエストです。",
+				},
+			});
+			await assertNotStored();
+		});
+
+		it("data: スキームのURLは登録できずVALIDATION_ERRORを返す", async () => {
+			const result = await storeListItem({
+				publicListId: testPublicListId,
+				movie: buildMovieWithUrl(
+					"data:text/html,<script>alert(1)</script>",
+				),
+			});
+
+			expect(result).toEqual({
+				success: false,
+				error: {
+					code: "VALIDATION_ERROR",
+					message: "不正なリクエストです。",
+				},
+			});
+			await assertNotStored();
+		});
+
+		it("vbscript: スキームのURLは登録できずVALIDATION_ERRORを返す", async () => {
+			const result = await storeListItem({
+				publicListId: testPublicListId,
+				movie: buildMovieWithUrl("vbscript:msgbox(1)"),
+			});
+
+			expect(result).toEqual({
+				success: false,
+				error: {
+					code: "VALIDATION_ERROR",
+					message: "不正なリクエストです。",
+				},
+			});
+			await assertNotStored();
+		});
+	});
+
+	describe("所有権チェック（IDOR対策）", () => {
+		const buildMovie = (): ListItem => ({
+			listItemId: crypto.randomUUID(),
+			title: "侵入テスト映画",
+			url: "https://www.netflix.com/jp/title/80100172",
+			serviceSlug: "netflix",
+			serviceName: "Netflix",
+			createdAt: new Date(),
+			isWatched: false,
+			watchedAt: null,
+		});
+
+		it("未認証ユーザーは作品を登録できずUNAUTHORIZED_ERRORを返す", async () => {
+			mockCurrentUserId.mockResolvedValue({
+				success: false,
+				error: { code: "UNAUTHORIZED_ERROR", message: "ログインしていません。" },
+			});
+
+			const result = await storeListItem({
+				publicListId: testPublicListId,
+				movie: buildMovie(),
+			});
+
+			expect(result.success).toBe(false);
+			if (result.success) {
+				return;
+			}
+			expect(result.error.code).toBe("UNAUTHORIZED_ERROR");
+
+			const storedListItems = await db
+				.select({ id: listItemsTable.id })
+				.from(listItemsTable)
+				.where(eq(listItemsTable.listId, testListId));
+			expect(storedListItems).toHaveLength(0);
+		});
+
+		it("他人のリストへは作品を登録できずFORBIDDEN_ERRORを返す", async () => {
+			const [attacker] = await db
+				.insert(usersTable)
+				.values({ publicId: "store-list-item-attacker-user" })
+				.returning({ id: usersTable.id });
+			await db.insert(listsTable).values({
+				publicId: crypto.randomUUID(),
+				userId: attacker.id,
+			});
+
+			mockCurrentUserId.mockResolvedValue({
+				success: true,
+				data: { userId: attacker.id },
+			});
+
+			const result = await storeListItem({
+				publicListId: testPublicListId,
+				movie: buildMovie(),
+			});
+
+			expect(result.success).toBe(false);
+			if (result.success) {
+				return;
+			}
+			expect(result.error.code).toBe("FORBIDDEN_ERROR");
+
+			const storedListItems = await db
+				.select({ id: listItemsTable.id })
+				.from(listItemsTable)
+				.where(eq(listItemsTable.listId, testListId));
+			expect(storedListItems).toHaveLength(0);
+		});
 	});
 });

--- a/features/list/actions/storeListItem.ts
+++ b/features/list/actions/storeListItem.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import z from "zod";
+import { currentUserId } from "@/features/shared/actions/currentUserId";
 import type { Result } from "@/features/shared/types/Result";
 import type { ListItem } from "../types/ListItem";
 import { listItemSchema } from "@/features/shared/schemas/listItemSchema";
@@ -36,11 +37,24 @@ export async function storeListItem({
 		};
 	}
 
+	const authResult = await currentUserId();
+
+	if (!authResult.success) {
+		return {
+			success: false,
+			error: {
+				code: "UNAUTHORIZED_ERROR",
+				message: "ログインかユーザー登録をしてください。",
+			},
+		};
+	}
+
 	const now = new Date();
 
 	return await storeListItemService({
 		publicListId,
 		movie,
 		now,
+		userId: authResult.data.userId,
 	});
 }

--- a/features/list/actions/toggleWatchStatus.test.ts
+++ b/features/list/actions/toggleWatchStatus.test.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import { eq } from "drizzle-orm";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "@/db/client";
 import {
 	listItemsTable,
@@ -14,11 +14,20 @@ import type { ListItem } from "@/features/list/types/ListItem";
 import { computeHmac, encrypt } from "@/features/shared/lib/encryption";
 import { toggleWatchStatus } from "./toggleWatchStatus";
 
+const { mockCurrentUserId } = vi.hoisted(() => ({
+	mockCurrentUserId: vi.fn(),
+}));
+
+vi.mock("@/features/shared/actions/currentUserId", () => ({
+	currentUserId: mockCurrentUserId,
+}));
+
 describe("toggleWatchStatus", () => {
 	let testListId: number;
 	let testListItemId: number;
 	let testListItemPublicId: string;
 	let testStreamingServiceId: number;
+	let ownerUserId: number;
 
 	beforeEach(async () => {
 		const [user] = await db
@@ -47,6 +56,7 @@ describe("toggleWatchStatus", () => {
 			throw Error("streaming_services_table に netflix が存在しません");
 		}
 
+		ownerUserId = user.id;
 		testListId = list.id;
 		testStreamingServiceId = streamingService.id;
 
@@ -64,6 +74,11 @@ describe("toggleWatchStatus", () => {
 			.returning({ id: listItemsTable.id });
 
 		testListItemId = listItem.id;
+
+		mockCurrentUserId.mockResolvedValue({
+			success: true,
+			data: { userId: ownerUserId },
+		});
 	});
 
 	it("視聴済みに変更できる", async () => {
@@ -191,6 +206,79 @@ describe("toggleWatchStatus", () => {
 		}
 
 		expect(result.error.message).toBe("作品がリストに登録されていません。");
+	});
+
+	describe("所有権チェック（IDOR対策）", () => {
+		const buildMockListItem = (overrides?: Partial<ListItem>): ListItem => ({
+			listItemId: testListItemPublicId,
+			title: "テスト映画",
+			url: "https://www.netflix.com/jp/title/80100172",
+			serviceSlug: "netflix",
+			serviceName: "Netflix",
+			createdAt: new Date(),
+			isWatched: false,
+			watchedAt: null,
+			...overrides,
+		});
+
+		it("未認証ユーザーは視聴状態を変更できずUNAUTHORIZED_ERRORを返す", async () => {
+			mockCurrentUserId.mockResolvedValue({
+				success: false,
+				error: { code: "UNAUTHORIZED_ERROR", message: "ログインしていません。" },
+			});
+
+			const result = await toggleWatchStatus({
+				listItemId: testListItemPublicId,
+				isWatched: true,
+				currentListItem: buildMockListItem(),
+			});
+
+			expect(result.success).toBe(false);
+			if (result.success) {
+				return;
+			}
+			expect(result.error.code).toBe("UNAUTHORIZED_ERROR");
+
+			const watchedItems = await db
+				.select()
+				.from(watchedItemsTable)
+				.where(eq(watchedItemsTable.listItemId, testListItemId));
+			expect(watchedItems).toHaveLength(0);
+		});
+
+		it("他人の作品の視聴状態は変更できずFORBIDDEN_ERRORを返す", async () => {
+			const [attacker] = await db
+				.insert(usersTable)
+				.values({ publicId: "toggle-watch-status-attacker-user" })
+				.returning({ id: usersTable.id });
+			await db.insert(listsTable).values({
+				publicId: crypto.randomUUID(),
+				userId: attacker.id,
+			});
+
+			mockCurrentUserId.mockResolvedValue({
+				success: true,
+				data: { userId: attacker.id },
+			});
+
+			const result = await toggleWatchStatus({
+				listItemId: testListItemPublicId,
+				isWatched: true,
+				currentListItem: buildMockListItem(),
+			});
+
+			expect(result.success).toBe(false);
+			if (result.success) {
+				return;
+			}
+			expect(result.error.code).toBe("FORBIDDEN_ERROR");
+
+			const watchedItems = await db
+				.select()
+				.from(watchedItemsTable)
+				.where(eq(watchedItemsTable.listItemId, testListItemId));
+			expect(watchedItems).toHaveLength(0);
+		});
 	});
 
 	it("視聴済み解除時に既存レコードがない場合はNOT_FOUND_ERRORを返す", async () => {

--- a/features/list/actions/toggleWatchStatus.ts
+++ b/features/list/actions/toggleWatchStatus.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { z } from "zod";
+import { currentUserId } from "@/features/shared/actions/currentUserId";
 import type { Result } from "@/features/shared/types/Result";
 import type { ListItem } from "@/features/list/types/ListItem";
 import { toggleWatchStatusService } from "@/features/list/services/toggleWatchStatusService";
@@ -39,9 +40,22 @@ export async function toggleWatchStatus({
 		};
 	}
 
+	const authResult = await currentUserId();
+
+	if (!authResult.success) {
+		return {
+			success: false,
+			error: {
+				code: "UNAUTHORIZED_ERROR",
+				message: "ログインかユーザー登録をしてください。",
+			},
+		};
+	}
+
 	return await toggleWatchStatusService({
 		listItemId: parsed.data.listItemId,
 		isWatched: parsed.data.isWatched,
 		currentListItem,
+		userId: authResult.data.userId,
 	});
 }

--- a/features/list/repositories/server/listRepository.ts
+++ b/features/list/repositories/server/listRepository.ts
@@ -439,6 +439,17 @@ export async function findIntListItemIdByPublicId(listItemPublicId: string) {
 	return listItem?.id ?? null;
 }
 
+export async function findListItemWithListIdByPublicId(
+	listItemPublicId: string,
+): Promise<{ id: number; listId: number } | null> {
+	const [listItem] = await db
+		.select({ id: listItemsTable.id, listId: listItemsTable.listId })
+		.from(listItemsTable)
+		.where(eq(listItemsTable.publicId, listItemPublicId));
+
+	return listItem ?? null;
+}
+
 export async function insertWatchedItem(
 	listItemId: number,
 	watchedAt: Date,

--- a/features/list/services/manageSubListItemService.test.ts
+++ b/features/list/services/manageSubListItemService.test.ts
@@ -27,8 +27,10 @@ async function findStreamingServiceIdBySlug(slug: "netflix") {
 
 describe("manageSubListItemService", () => {
 	let subListId = 0;
+	let subListPublicId = "";
 	let listItemId = 0;
 	let listItemPublicId = "";
+	let userId = 0;
 
 	beforeEach(async () => {
 		await db.delete(subListItemsTable);
@@ -41,16 +43,18 @@ describe("manageSubListItemService", () => {
 			.insert(usersTable)
 			.values({ publicId: "manage-sub-list-item-service-user" })
 			.returning({ id: usersTable.id });
+		userId = user.id;
 
 		const [list] = await db
 			.insert(listsTable)
 			.values({ publicId: crypto.randomUUID(), userId: user.id })
 			.returning({ id: listsTable.id });
 
+		subListPublicId = crypto.randomUUID();
 		const [subList] = await db
 			.insert(subListsTable)
 			.values({
-				publicId: crypto.randomUUID(),
+				publicId: subListPublicId,
 				listId: list.id,
 				name: "テストサブリスト",
 				createdAt: new Date(),
@@ -78,8 +82,9 @@ describe("manageSubListItemService", () => {
 	describe("add アクション", () => {
 		it("アイテムをサブリストへ追加できる", async () => {
 			const result = await manageSubListItemService({
-				subListId,
+				subListPublicId,
 				listItemPublicId,
+				userId,
 				action: "add",
 			});
 
@@ -96,8 +101,9 @@ describe("manageSubListItemService", () => {
 
 		it("存在しないlistItemPublicIdでは失敗する", async () => {
 			const result = await manageSubListItemService({
-				subListId,
+				subListPublicId,
 				listItemPublicId: crypto.randomUUID(),
+				userId,
 				action: "add",
 			});
 
@@ -116,8 +122,9 @@ describe("manageSubListItemService", () => {
 				.values({ subListId, listItemId });
 
 			const result = await manageSubListItemService({
-				subListId,
+				subListPublicId,
 				listItemPublicId,
+				userId,
 				action: "remove",
 			});
 

--- a/features/list/services/manageSubListItemService.ts
+++ b/features/list/services/manageSubListItemService.ts
@@ -2,22 +2,50 @@ import { db } from "@/db/client";
 import type { Result } from "@/features/shared/types/Result";
 import {
 	deleteSubListItem,
-	findIntListItemIdByPublicId,
+	findListIdByUserId,
+	findListItemWithListIdByPublicId,
+	findSubListByPublicId,
 	insertSubListItem,
 } from "../repositories/server/listRepository";
 
 export const manageSubListItemService = async ({
-	subListId,
+	subListPublicId,
 	listItemPublicId,
+	userId,
 	action,
 }: {
-	subListId: number;
+	subListPublicId: string;
 	listItemPublicId: string;
+	userId: number;
 	action: "add" | "remove";
 }): Promise<Result> => {
-	const listItemId = await findIntListItemIdByPublicId(listItemPublicId);
+	const [subList, listItem, userListIdValue] = await Promise.all([
+		findSubListByPublicId(subListPublicId),
+		findListItemWithListIdByPublicId(listItemPublicId),
+		findListIdByUserId(userId),
+	]);
 
-	if (listItemId === null) {
+	if (!subList) {
+		return {
+			success: false,
+			error: {
+				code: "NOT_FOUND_ERROR",
+				message: "サブリストが見つかりませんでした。",
+			},
+		};
+	}
+
+	if (subList.listId !== userListIdValue) {
+		return {
+			success: false,
+			error: {
+				code: "FORBIDDEN_ERROR",
+				message: "このサブリストを操作する権限がありません。",
+			},
+		};
+	}
+
+	if (!listItem) {
 		return {
 			success: false,
 			error: {
@@ -27,12 +55,25 @@ export const manageSubListItemService = async ({
 		};
 	}
 
+	if (listItem.listId !== userListIdValue) {
+		return {
+			success: false,
+			error: {
+				code: "FORBIDDEN_ERROR",
+				message: "このリストアイテムを操作する権限がありません。",
+			},
+		};
+	}
+
 	if (action === "add") {
 		await db.transaction(async (tx) => {
-			await insertSubListItem(tx, { subListId, listItemId });
+			await insertSubListItem(tx, {
+				subListId: subList.id,
+				listItemId: listItem.id,
+			});
 		});
 	} else {
-		await deleteSubListItem(subListId, listItemId);
+		await deleteSubListItem(subList.id, listItem.id);
 	}
 
 	return { success: true };

--- a/features/list/services/removeListItemService.ts
+++ b/features/list/services/removeListItemService.ts
@@ -1,14 +1,43 @@
 import type { Result } from "@/features/shared/types/Result";
 import {
 	deleteListItemByPublicId,
+	findListIdByUserId,
+	findListItemWithListIdByPublicId,
 } from "@/features/list/repositories/server/listRepository";
 
 export async function removeListItemService({
 	listItemId,
+	userId,
 }: {
 	listItemId: string;
+	userId: number;
 }): Promise<Result> {
 	try {
+		const [listItem, userListIdValue] = await Promise.all([
+			findListItemWithListIdByPublicId(listItemId),
+			findListIdByUserId(userId),
+		]);
+
+		if (!listItem) {
+			return {
+				success: false,
+				error: {
+					code: "NOT_FOUND_ERROR",
+					message: "作品がリストへ登録されていないか、すでに削除されています。",
+				},
+			};
+		}
+
+		if (listItem.listId !== userListIdValue) {
+			return {
+				success: false,
+				error: {
+					code: "FORBIDDEN_ERROR",
+					message: "この作品を削除する権限がありません。",
+				},
+			};
+		}
+
 		const deletedListItemId = await deleteListItemByPublicId(listItemId);
 		if (!deletedListItemId) {
 			return {

--- a/features/list/services/storeListItemService.ts
+++ b/features/list/services/storeListItemService.ts
@@ -2,6 +2,7 @@ import type { Result } from "@/features/shared/types/Result";
 import type { ListItem } from "@/features/list/types/ListItem";
 import {
 	findListIdByPublicId,
+	findListIdByUserId,
 	findListItemIdByPublicIdAndListId,
 	findStreamingServiceBySlug,
 	insertListItem,
@@ -12,18 +13,34 @@ export async function storeListItemService({
 	publicListId,
 	movie,
 	now,
+	userId,
 }: {
 	publicListId: string;
 	movie: ListItem;
 	now: Date;
+	userId: number;
 }): Promise<Result<ListItem>> {
-	const listId = await findListIdByPublicId(publicListId);
+	const [listId, userListIdValue] = await Promise.all([
+		findListIdByPublicId(publicListId),
+		findListIdByUserId(userId),
+	]);
+
 	if (listId === null) {
 		return {
 			success: false,
 			error: {
 				code: "NOT_FOUND_ERROR",
 				message: "リストが見つかりませんでした。",
+			},
+		};
+	}
+
+	if (listId !== userListIdValue) {
+		return {
+			success: false,
+			error: {
+				code: "FORBIDDEN_ERROR",
+				message: "このリストへ作品を登録する権限がありません。",
 			},
 		};
 	}

--- a/features/list/services/toggleWatchStatusService.ts
+++ b/features/list/services/toggleWatchStatusService.ts
@@ -1,24 +1,30 @@
 import type { Result } from "@/features/shared/types/Result";
 import type { ListItem } from "@/features/list/types/ListItem";
 import {
-	findIntListItemIdByPublicId,
-	insertWatchedItem,
 	deleteWatchedItem,
+	findListIdByUserId,
+	findListItemWithListIdByPublicId,
+	insertWatchedItem,
 } from "@/features/list/repositories/server/listRepository";
 
 export async function toggleWatchStatusService({
 	listItemId,
 	isWatched,
 	currentListItem,
+	userId,
 }: {
 	listItemId: string;
 	isWatched: boolean;
 	currentListItem: ListItem;
+	userId: number;
 }): Promise<Result<ListItem>> {
 	try {
-		// 1. listItemId を int に変換
-		const intListItemId = await findIntListItemIdByPublicId(listItemId);
-		if (!intListItemId) {
+		const [listItem, userListIdValue] = await Promise.all([
+			findListItemWithListIdByPublicId(listItemId),
+			findListIdByUserId(userId),
+		]);
+
+		if (!listItem) {
 			return {
 				success: false,
 				error: {
@@ -28,11 +34,20 @@ export async function toggleWatchStatusService({
 			};
 		}
 
-		// 2. isWatched の状態に応じて INSERT/DELETE
+		if (listItem.listId !== userListIdValue) {
+			return {
+				success: false,
+				error: {
+					code: "FORBIDDEN_ERROR",
+					message: "この作品の視聴状態を変更する権限がありません。",
+				},
+			};
+		}
+
 		if (isWatched) {
-			await insertWatchedItem(intListItemId, new Date());
+			await insertWatchedItem(listItem.id, new Date());
 		} else {
-			const deleted = await deleteWatchedItem(intListItemId);
+			const deleted = await deleteWatchedItem(listItem.id);
 			if (!deleted) {
 				return {
 					success: false,
@@ -44,8 +59,7 @@ export async function toggleWatchStatusService({
 			}
 		}
 
-		// 3. 更新後の ListItem を構築
-		const listItem: ListItem = isWatched
+		const updated: ListItem = isWatched
 			? {
 					...currentListItem,
 					isWatched: true,
@@ -59,7 +73,7 @@ export async function toggleWatchStatusService({
 
 		return {
 			success: true,
-			data: listItem,
+			data: updated,
 		};
 	} catch (error) {
 		console.error(error);

--- a/features/shared/lib/getClientIp.ts
+++ b/features/shared/lib/getClientIp.ts
@@ -1,0 +1,13 @@
+type ReadonlyHeaders = {
+	get(name: string): string | null;
+};
+
+// Vercel エッジが管理する信頼ヘッダから本物のクライアントIPを取得する。
+// x-forwarded-for は左端をクライアントが偽装できるため使わない。
+export function getClientIp(headersList: ReadonlyHeaders): string {
+	return (
+		headersList.get("x-vercel-forwarded-for") ||
+		headersList.get("x-real-ip") ||
+		"unknown"
+	);
+}

--- a/features/shared/schemas/listItemSchema.ts
+++ b/features/shared/schemas/listItemSchema.ts
@@ -17,11 +17,23 @@ const supportedServiceNameSchema = z.enum([
 	SUPPORTED_SERVICES.DISNEY_PLUS.name,
 ]);
 
+const httpUrlSchema = z.url().refine(
+	(value) => {
+		try {
+			const protocol = new URL(value).protocol;
+			return protocol === "http:" || protocol === "https:";
+		} catch {
+			return false;
+		}
+	},
+	{ message: "URLは http または https のみ許可されます。" },
+);
+
 const listItemDetailsSchema = z.object({
 	movieId: z.number().int().positive(),
 	officialTitle: z.string().min(1),
-	backgroundImage: z.url(),
-	posterImage: z.url(),
+	backgroundImage: httpUrlSchema,
+	posterImage: httpUrlSchema,
 	director: z.array(z.string().min(1)),
 	runningMinutes: z.number().int().positive(),
 	releaseYear: z.number().int(),
@@ -33,7 +45,7 @@ const listItemDetailsSchema = z.object({
 const listItemBaseSchema = z.object({
 	listItemId: z.uuid(),
 	title: z.string().min(1),
-	url: z.url(),
+	url: httpUrlSchema,
 	serviceSlug: supportedServiceSlugSchema,
 	serviceName: supportedServiceNameSchema,
 	createdAt: z.coerce.date(),

--- a/features/user/actions/changeEmail.ts
+++ b/features/user/actions/changeEmail.ts
@@ -5,6 +5,7 @@ import z from "zod";
 import type { Result } from "@/features/shared/types/Result";
 import { currentUserId } from "@/features/shared/actions/currentUserId";
 import { currentUserEmail } from "@/features/shared/actions/currentUserEmail";
+import { getClientIp } from "@/features/shared/lib/getClientIp";
 import { checkRateLimitService } from "@/features/auth/services/checkRateLimitService";
 import { loginCodeSchema } from "@/features/auth/schemas/loginSchemas";
 import { changeEmailService } from "../services/changeEmailService";
@@ -69,13 +70,12 @@ export async function changeEmail(
 	}
 
 	const headersList = await headers();
-	const ipAddress =
-		headersList.get("x-forwarded-for")?.split(",")[0] ||
-		headersList.get("x-real-ip") ||
-		"unknown";
+	const ipAddress = getClientIp(headersList);
+	const target = emailParsed.data.email;
 
 	const { limit } = await checkRateLimitService({
 		ipAddress,
+		target,
 		attemptType: "code_verify",
 		now,
 	});
@@ -99,6 +99,7 @@ export async function changeEmail(
 		userId: userIdResult.data.userId,
 		reauthToken,
 		ipAddress,
+		target,
 		now,
 	});
 

--- a/features/user/actions/sendCodeToNewEmail.ts
+++ b/features/user/actions/sendCodeToNewEmail.ts
@@ -4,6 +4,7 @@ import { cookies, headers } from "next/headers";
 import z from "zod";
 import type { Result } from "@/features/shared/types/Result";
 import { currentUserEmail } from "@/features/shared/actions/currentUserEmail";
+import { getClientIp } from "@/features/shared/lib/getClientIp";
 import { checkRateLimitService } from "@/features/auth/services/checkRateLimitService";
 import { sendCodeToNewEmailService } from "../services/sendCodeToNewEmailService";
 
@@ -37,13 +38,12 @@ export async function sendCodeToNewEmail(newEmail: string): Promise<Result> {
 	}
 
 	const headersList = await headers();
-	const ipAddress =
-		headersList.get("x-forwarded-for")?.split(",")[0] ||
-		headersList.get("x-real-ip") ||
-		"unknown";
+	const ipAddress = getClientIp(headersList);
+	const target = parsed.data.email;
 
 	const { limit } = await checkRateLimitService({
 		ipAddress,
+		target,
 		attemptType: "code_send",
 		now,
 	});
@@ -74,6 +74,7 @@ export async function sendCodeToNewEmail(newEmail: string): Promise<Result> {
 	return await sendCodeToNewEmailService({
 		newEmail: parsed.data.email,
 		ipAddress,
+		target,
 		now,
 	});
 }

--- a/features/user/services/changeEmailService.ts
+++ b/features/user/services/changeEmailService.ts
@@ -17,6 +17,7 @@ export async function changeEmailService({
 	userId,
 	reauthToken,
 	ipAddress,
+	target,
 	now,
 }: {
 	newEmail: string;
@@ -24,6 +25,7 @@ export async function changeEmailService({
 	userId: number;
 	reauthToken: string;
 	ipAddress: string;
+	target: string;
 	now: Date;
 }): Promise<Result> {
 	try {
@@ -50,6 +52,7 @@ export async function changeEmailService({
 				await insertAttempt({
 					tx,
 					ipAddress,
+					target,
 					attemptType: "code_verify",
 					success: false,
 				});
@@ -65,6 +68,7 @@ export async function changeEmailService({
 			await insertAttempt({
 				tx,
 				ipAddress,
+				target,
 				attemptType: "code_verify",
 				success: true,
 			});

--- a/features/user/services/sendCodeToNewEmailService.ts
+++ b/features/user/services/sendCodeToNewEmailService.ts
@@ -5,10 +5,12 @@ import { checkEmailExists } from "../repositories/userEmailRepository";
 export async function sendCodeToNewEmailService({
 	newEmail,
 	ipAddress,
+	target,
 	now,
 }: {
 	newEmail: string;
 	ipAddress: string;
+	target: string;
 	now: Date;
 }): Promise<Result> {
 	const emailTaken = await checkEmailExists(newEmail);
@@ -22,5 +24,10 @@ export async function sendCodeToNewEmailService({
 		};
 	}
 
-	return await sendLoginCodeService({ email: newEmail, ipAddress, now });
+	return await sendLoginCodeService({
+		email: newEmail,
+		ipAddress,
+		target,
+		now,
+	});
 }

--- a/migrations/0039_cold_marvel_boy.sql
+++ b/migrations/0039_cold_marvel_boy.sql
@@ -1,0 +1,2 @@
+DELETE FROM `login_attempts_table`;--> statement-breakpoint
+ALTER TABLE `login_attempts_table` ADD `target_hmac` text NOT NULL;

--- a/migrations/meta/0039_snapshot.json
+++ b/migrations/meta/0039_snapshot.json
@@ -1,0 +1,1141 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "dbdf868f-b900-4871-804f-120f05306479",
+  "prevId": "bf69a25b-fc06-4660-aa7f-186233776d3d",
+  "tables": {
+    "deleted_users_table": {
+      "name": "deleted_users_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "director_cache_table": {
+      "name": "director_cache_table",
+      "columns": {
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "director_cache_table_movieId_movies_table_id_fk": {
+          "name": "director_cache_table_movieId_movies_table_id_fk",
+          "tableFrom": "director_cache_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "directors_table": {
+      "name": "directors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_item_movie_match_table": {
+      "name": "list_item_movie_match_table",
+      "columns": {
+        "list_item_id": {
+          "name": "list_item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "list_item_movie_match_table_list_item_id_list_items_table_id_fk": {
+          "name": "list_item_movie_match_table_list_item_id_list_items_table_id_fk",
+          "tableFrom": "list_item_movie_match_table",
+          "tableTo": "list_items_table",
+          "columnsFrom": [
+            "list_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_item_movie_match_table_movie_id_movies_table_id_fk": {
+          "name": "list_item_movie_match_table_movie_id_movies_table_id_fk",
+          "tableFrom": "list_item_movie_match_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "list_items_table": {
+      "name": "list_items_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "listId": {
+          "name": "listId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "streamingServiceId": {
+          "name": "streamingServiceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watchUrl": {
+          "name": "watchUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "titleOnService": {
+          "name": "titleOnService",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "list_items_table_publicId_unique": {
+          "name": "list_items_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        },
+        "list_items_table_listId_watchUrl_unique": {
+          "name": "list_items_table_listId_watchUrl_unique",
+          "columns": [
+            "listId",
+            "watchUrl"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "list_items_table_listId_lists_table_id_fk": {
+          "name": "list_items_table_listId_lists_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "lists_table",
+          "columnsFrom": [
+            "listId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_items_table_streamingServiceId_streaming_services_table_id_fk": {
+          "name": "list_items_table_streamingServiceId_streaming_services_table_id_fk",
+          "tableFrom": "list_items_table",
+          "tableTo": "streaming_services_table",
+          "columnsFrom": [
+            "streamingServiceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lists_table": {
+      "name": "lists_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "lists_table_publicId_unique": {
+          "name": "lists_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        },
+        "lists_table_userId_unique": {
+          "name": "lists_table_userId_unique",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "lists_table_userId_users_table_id_fk": {
+          "name": "lists_table_userId_users_table_id_fk",
+          "tableFrom": "lists_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "login_attempts_table": {
+      "name": "login_attempts_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ip_address_hmac": {
+          "name": "ip_address_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_hmac": {
+          "name": "target_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt_type": {
+          "name": "attempt_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "login_codes_table": {
+      "name": "login_codes_table",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_hmac": {
+          "name": "email_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_email": {
+          "name": "encrypted_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "login_codes_table_token_unique": {
+          "name": "login_codes_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "login_codes_table_user_id_users_table_id_fk": {
+          "name": "login_codes_table_user_id_users_table_id_fk",
+          "tableFrom": "login_codes_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_cache_table": {
+      "name": "movie_cache_table",
+      "columns": {
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movie_cache_table_movieId_movies_table_id_fk": {
+          "name": "movie_cache_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_cache_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_directors_table": {
+      "name": "movie_directors_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "directorId": {
+          "name": "directorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "movie_directors_movie_id_director_id_unique": {
+          "name": "movie_directors_movie_id_director_id_unique",
+          "columns": [
+            "movieId",
+            "directorId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "movie_directors_table_movieId_movies_table_id_fk": {
+          "name": "movie_directors_table_movieId_movies_table_id_fk",
+          "tableFrom": "movie_directors_table",
+          "tableTo": "movies_table",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movie_directors_table_directorId_directors_table_id_fk": {
+          "name": "movie_directors_table_directorId_directors_table_id_fk",
+          "tableFrom": "movie_directors_table",
+          "tableTo": "directors_table",
+          "columnsFrom": [
+            "directorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies_table": {
+      "name": "movies_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "externalDatabaseMovieId": {
+          "name": "externalDatabaseMovieId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backgroundImage": {
+          "name": "backgroundImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posterImage": {
+          "name": "posterImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runningMinutes": {
+          "name": "runningMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "releaseDate": {
+          "name": "releaseDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "movies_table_externalDatabaseMovieId_unique": {
+          "name": "movies_table_externalDatabaseMovieId_unique",
+          "columns": [
+            "externalDatabaseMovieId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reauth_tokens_table": {
+      "name": "reauth_tokens_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reauth_tokens_table_token_unique": {
+          "name": "reauth_tokens_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "reauth_tokens_table_user_id_users_table_id_fk": {
+          "name": "reauth_tokens_table_user_id_users_table_id_fk",
+          "tableFrom": "reauth_tokens_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_tokens_table": {
+      "name": "session_tokens_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_tokens_table_token_unique": {
+          "name": "session_tokens_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_tokens_table_user_id_users_table_id_fk": {
+          "name": "session_tokens_table_user_id_users_table_id_fk",
+          "tableFrom": "session_tokens_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "streaming_services_table": {
+      "name": "streaming_services_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "streaming_services_table_slug_unique": {
+          "name": "streaming_services_table_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sub_list_items_table": {
+      "name": "sub_list_items_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "sub_list_id": {
+          "name": "sub_list_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "list_item_id": {
+          "name": "list_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sub_list_items_sub_list_id_list_item_id_unique": {
+          "name": "sub_list_items_sub_list_id_list_item_id_unique",
+          "columns": [
+            "sub_list_id",
+            "list_item_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sub_list_items_table_sub_list_id_sub_lists_table_id_fk": {
+          "name": "sub_list_items_table_sub_list_id_sub_lists_table_id_fk",
+          "tableFrom": "sub_list_items_table",
+          "tableTo": "sub_lists_table",
+          "columnsFrom": [
+            "sub_list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sub_list_items_table_list_item_id_list_items_table_id_fk": {
+          "name": "sub_list_items_table_list_item_id_list_items_table_id_fk",
+          "tableFrom": "sub_list_items_table",
+          "tableTo": "list_items_table",
+          "columnsFrom": [
+            "list_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sub_lists_table": {
+      "name": "sub_lists_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sub_lists_table_public_id_unique": {
+          "name": "sub_lists_table_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sub_lists_table_list_id_lists_table_id_fk": {
+          "name": "sub_lists_table_list_id_lists_table_id_fk",
+          "tableFrom": "sub_lists_table",
+          "tableTo": "lists_table",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "temp_session_tokens_table": {
+      "name": "temp_session_tokens_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_hmac": {
+          "name": "email_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_email": {
+          "name": "encrypted_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "temp_session_tokens_table_token_unique": {
+          "name": "temp_session_tokens_table_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_emails_table": {
+      "name": "user_emails_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_email": {
+          "name": "encrypted_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_hmac": {
+          "name": "email_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_emails_table_email_hmac_unique": {
+          "name": "user_emails_table_email_hmac_unique",
+          "columns": [
+            "email_hmac"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_emails_table_user_id_users_table_id_fk": {
+          "name": "user_emails_table_user_id_users_table_id_fk",
+          "tableFrom": "user_emails_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users_table": {
+      "name": "users_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_table_publicId_unique": {
+          "name": "users_table_publicId_unique",
+          "columns": [
+            "publicId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watched_items_table": {
+      "name": "watched_items_table",
+      "columns": {
+        "list_item_id": {
+          "name": "list_item_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watched_at": {
+          "name": "watched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watched_items_table_list_item_id_list_items_table_id_fk": {
+          "name": "watched_items_table_list_item_id_list_items_table_id_fk",
+          "tableFrom": "watched_items_table",
+          "tableTo": "list_items_table",
+          "columnsFrom": [
+            "list_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1776832069323,
       "tag": "0038_jazzy_dormammu",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "6",
+      "when": 1781843310360,
+      "tag": "0039_cold_marvel_boy",
+      "breakpoints": true
     }
   ]
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,40 @@
 import type { NextConfig } from "next";
 
+const cspDirectives = [
+	"default-src 'self'",
+	"script-src 'self' 'unsafe-inline'",
+	"style-src 'self' 'unsafe-inline'",
+	"img-src 'self' data: blob: https://image.tmdb.org",
+	"font-src 'self' data:",
+	"connect-src 'self'",
+	"frame-ancestors 'none'",
+	"form-action 'self'",
+	"base-uri 'self'",
+	"object-src 'none'",
+	"upgrade-insecure-requests",
+].join("; ");
+
+const securityHeaders = [
+	{ key: "Content-Security-Policy", value: cspDirectives },
+	{ key: "X-Frame-Options", value: "DENY" },
+	{ key: "X-Content-Type-Options", value: "nosniff" },
+	{ key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+	{
+		key: "Strict-Transport-Security",
+		value: "max-age=63072000; includeSubDomains",
+	},
+];
+
 const nextConfig: NextConfig = {
 	devIndicators: false,
+	async headers() {
+		return [
+			{
+				source: "/:path*",
+				headers: securityHeaders,
+			},
+		];
+	},
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "risutopo",
+	"name": "listpot",
 	"version": "0.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "risutopo",
+			"name": "listpot",
 			"version": "0.1.0",
 			"dependencies": {
 				"@hookform/resolvers": "^5.4.0",
@@ -84,13 +84,13 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/helper-validator-identifier": "^7.29.7",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.1.1"
 			},
@@ -99,9 +99,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-			"integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+			"integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {
@@ -109,21 +109,21 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-compilation-targets": "^7.28.6",
-				"@babel/helper-module-transforms": "^7.28.6",
-				"@babel/helpers": "^7.28.6",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/traverse": "^7.29.0",
-				"@babel/types": "^7.29.0",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-compilation-targets": "^7.29.7",
+				"@babel/helper-module-transforms": "^7.29.7",
+				"@babel/helpers": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
@@ -140,14 +140,14 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.29.1",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+			"integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.29.0",
-				"@babel/types": "^7.29.0",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"@jridgewell/gen-mapping": "^0.3.12",
 				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
@@ -157,14 +157,14 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+			"integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.28.6",
-				"@babel/helper-validator-option": "^7.27.1",
+				"@babel/compat-data": "^7.29.7",
+				"@babel/helper-validator-option": "^7.29.7",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
@@ -174,9 +174,9 @@
 			}
 		},
 		"node_modules/@babel/helper-globals": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+			"integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {
@@ -184,29 +184,29 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+			"integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/traverse": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+			"integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.28.6",
-				"@babel/helper-validator-identifier": "^7.28.5",
-				"@babel/traverse": "^7.28.6"
+				"@babel/helper-module-imports": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"@babel/traverse": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -216,9 +216,9 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {
@@ -226,9 +226,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {
@@ -236,9 +236,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+			"integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {
@@ -246,27 +246,27 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+			"integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.29.0"
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+			"integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.29.0"
+				"@babel/types": "^7.29.7"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -287,33 +287,33 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+			"integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.28.6",
-				"@babel/parser": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/code-frame": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+			"integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.29.0",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-globals": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"debug": "^4.3.1"
 			},
 			"engines": {
@@ -321,14 +321,14 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+			"integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.28.5"
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -6745,6 +6745,16 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
 		"node_modules/base64id": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
@@ -6765,6 +6775,19 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/browserslist": {
@@ -8070,9 +8093,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.334",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz",
-			"integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
+			"version": "1.5.376",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
+			"integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
 			"devOptional": true,
 			"license": "ISC"
 		},
@@ -8087,9 +8110,9 @@
 			}
 		},
 		"node_modules/engine.io": {
-			"version": "6.6.6",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.6.tgz",
-			"integrity": "sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==",
+			"version": "6.6.9",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
+			"integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8102,7 +8125,7 @@
 				"cors": "~2.8.5",
 				"debug": "~4.4.1",
 				"engine.io-parser": "~5.2.1",
-				"ws": "~8.18.3"
+				"ws": "~8.21.0"
 			},
 			"engines": {
 				"node": ">=10.2.0"
@@ -8116,28 +8139,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/engine.io/node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/enhanced-resolve": {
@@ -8320,9 +8321,9 @@
 			"license": "Unlicense"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -8490,29 +8491,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/glob/node_modules/balanced-match": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^4.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/glob/node_modules/minimatch": {
@@ -10373,11 +10351,14 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.37",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-			"integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+			"version": "2.0.48",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+			"integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
 			"devOptional": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -11002,9 +10983,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/aix-ppc64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-			"integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -11019,9 +11000,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/android-arm": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-			"integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
 			"cpu": [
 				"arm"
 			],
@@ -11036,9 +11017,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/android-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-			"integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
 			"cpu": [
 				"arm64"
 			],
@@ -11053,9 +11034,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/android-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-			"integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
 			"cpu": [
 				"x64"
 			],
@@ -11070,9 +11051,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-			"integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -11087,9 +11068,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/darwin-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-			"integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
 			"cpu": [
 				"x64"
 			],
@@ -11104,9 +11085,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
 			"cpu": [
 				"arm64"
 			],
@@ -11121,9 +11102,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-			"integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
 			"cpu": [
 				"x64"
 			],
@@ -11138,9 +11119,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/linux-arm": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-			"integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
 			"cpu": [
 				"arm"
 			],
@@ -11155,9 +11136,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/linux-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-			"integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
 			"cpu": [
 				"arm64"
 			],
@@ -11172,9 +11153,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/linux-ia32": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-			"integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
 			"cpu": [
 				"ia32"
 			],
@@ -11189,9 +11170,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/linux-loong64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-			"integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
 			"cpu": [
 				"loong64"
 			],
@@ -11206,9 +11187,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-			"integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
 			"cpu": [
 				"mips64el"
 			],
@@ -11223,9 +11204,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-			"integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -11240,9 +11221,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-			"integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -11257,9 +11238,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/linux-s390x": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-			"integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
 			"cpu": [
 				"s390x"
 			],
@@ -11274,9 +11255,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/linux-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-			"integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
 			"cpu": [
 				"x64"
 			],
@@ -11291,9 +11272,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
 			"cpu": [
 				"arm64"
 			],
@@ -11308,9 +11289,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-			"integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
 			"cpu": [
 				"x64"
 			],
@@ -11325,9 +11306,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -11342,9 +11323,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-			"integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
 			"cpu": [
 				"x64"
 			],
@@ -11359,9 +11340,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-			"integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
 			"cpu": [
 				"arm64"
 			],
@@ -11376,9 +11357,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/sunos-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-			"integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
 			"cpu": [
 				"x64"
 			],
@@ -11393,9 +11374,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/win32-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-			"integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
 			"cpu": [
 				"arm64"
 			],
@@ -11410,9 +11391,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/win32-ia32": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-			"integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
 			"cpu": [
 				"ia32"
 			],
@@ -11427,9 +11408,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/@esbuild/win32-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-			"integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
 			"cpu": [
 				"x64"
 			],
@@ -11454,9 +11435,9 @@
 			}
 		},
 		"node_modules/react-email/node_modules/esbuild": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-			"integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -11467,32 +11448,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.28.0",
-				"@esbuild/android-arm": "0.28.0",
-				"@esbuild/android-arm64": "0.28.0",
-				"@esbuild/android-x64": "0.28.0",
-				"@esbuild/darwin-arm64": "0.28.0",
-				"@esbuild/darwin-x64": "0.28.0",
-				"@esbuild/freebsd-arm64": "0.28.0",
-				"@esbuild/freebsd-x64": "0.28.0",
-				"@esbuild/linux-arm": "0.28.0",
-				"@esbuild/linux-arm64": "0.28.0",
-				"@esbuild/linux-ia32": "0.28.0",
-				"@esbuild/linux-loong64": "0.28.0",
-				"@esbuild/linux-mips64el": "0.28.0",
-				"@esbuild/linux-ppc64": "0.28.0",
-				"@esbuild/linux-riscv64": "0.28.0",
-				"@esbuild/linux-s390x": "0.28.0",
-				"@esbuild/linux-x64": "0.28.0",
-				"@esbuild/netbsd-arm64": "0.28.0",
-				"@esbuild/netbsd-x64": "0.28.0",
-				"@esbuild/openbsd-arm64": "0.28.0",
-				"@esbuild/openbsd-x64": "0.28.0",
-				"@esbuild/openharmony-arm64": "0.28.0",
-				"@esbuild/sunos-x64": "0.28.0",
-				"@esbuild/win32-arm64": "0.28.0",
-				"@esbuild/win32-ia32": "0.28.0",
-				"@esbuild/win32-x64": "0.28.0"
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
 			}
 		},
 		"node_modules/react-email/node_modules/jiti": {
@@ -12480,36 +12461,14 @@
 			}
 		},
 		"node_modules/socket.io-adapter": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
-			"integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+			"version": "2.5.8",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
+			"integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"debug": "~4.4.1",
-				"ws": "~8.18.3"
-			}
-		},
-		"node_modules/socket.io-adapter/node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
+				"ws": "~8.21.0"
 			}
 		},
 		"node_modules/socket.io-parser": {
@@ -12948,9 +12907,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-			"integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -12965,9 +12924,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/android-arm": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-			"integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
 			"cpu": [
 				"arm"
 			],
@@ -12982,9 +12941,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/android-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-			"integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
 			"cpu": [
 				"arm64"
 			],
@@ -12999,9 +12958,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/android-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-			"integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
 			"cpu": [
 				"x64"
 			],
@@ -13016,9 +12975,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-			"integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -13033,9 +12992,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/darwin-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-			"integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
 			"cpu": [
 				"x64"
 			],
@@ -13050,9 +13009,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
 			"cpu": [
 				"arm64"
 			],
@@ -13067,9 +13026,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-			"integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
 			"cpu": [
 				"x64"
 			],
@@ -13084,9 +13043,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/linux-arm": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-			"integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
 			"cpu": [
 				"arm"
 			],
@@ -13101,9 +13060,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/linux-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-			"integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
 			"cpu": [
 				"arm64"
 			],
@@ -13118,9 +13077,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/linux-ia32": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-			"integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
 			"cpu": [
 				"ia32"
 			],
@@ -13135,9 +13094,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/linux-loong64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-			"integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
 			"cpu": [
 				"loong64"
 			],
@@ -13152,9 +13111,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-			"integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
 			"cpu": [
 				"mips64el"
 			],
@@ -13169,9 +13128,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-			"integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -13186,9 +13145,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-			"integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -13203,9 +13162,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/linux-s390x": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-			"integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
 			"cpu": [
 				"s390x"
 			],
@@ -13220,9 +13179,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/linux-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-			"integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
 			"cpu": [
 				"x64"
 			],
@@ -13237,9 +13196,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
 			"cpu": [
 				"arm64"
 			],
@@ -13254,9 +13213,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-			"integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
 			"cpu": [
 				"x64"
 			],
@@ -13271,9 +13230,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -13288,9 +13247,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-			"integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
 			"cpu": [
 				"x64"
 			],
@@ -13305,9 +13264,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-			"integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
 			"cpu": [
 				"arm64"
 			],
@@ -13322,9 +13281,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/sunos-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-			"integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
 			"cpu": [
 				"x64"
 			],
@@ -13339,9 +13298,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/win32-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-			"integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
 			"cpu": [
 				"arm64"
 			],
@@ -13356,9 +13315,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/win32-ia32": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-			"integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
 			"cpu": [
 				"ia32"
 			],
@@ -13373,9 +13332,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/@esbuild/win32-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-			"integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
 			"cpu": [
 				"x64"
 			],
@@ -13390,9 +13349,9 @@
 			}
 		},
 		"node_modules/tsx/node_modules/esbuild": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-			"integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -13403,32 +13362,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.28.0",
-				"@esbuild/android-arm": "0.28.0",
-				"@esbuild/android-arm64": "0.28.0",
-				"@esbuild/android-x64": "0.28.0",
-				"@esbuild/darwin-arm64": "0.28.0",
-				"@esbuild/darwin-x64": "0.28.0",
-				"@esbuild/freebsd-arm64": "0.28.0",
-				"@esbuild/freebsd-x64": "0.28.0",
-				"@esbuild/linux-arm": "0.28.0",
-				"@esbuild/linux-arm64": "0.28.0",
-				"@esbuild/linux-ia32": "0.28.0",
-				"@esbuild/linux-loong64": "0.28.0",
-				"@esbuild/linux-mips64el": "0.28.0",
-				"@esbuild/linux-ppc64": "0.28.0",
-				"@esbuild/linux-riscv64": "0.28.0",
-				"@esbuild/linux-s390x": "0.28.0",
-				"@esbuild/linux-x64": "0.28.0",
-				"@esbuild/netbsd-arm64": "0.28.0",
-				"@esbuild/netbsd-x64": "0.28.0",
-				"@esbuild/openbsd-arm64": "0.28.0",
-				"@esbuild/openbsd-x64": "0.28.0",
-				"@esbuild/openharmony-arm64": "0.28.0",
-				"@esbuild/sunos-x64": "0.28.0",
-				"@esbuild/win32-arm64": "0.28.0",
-				"@esbuild/win32-ia32": "0.28.0",
-				"@esbuild/win32-x64": "0.28.0"
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
 			}
 		},
 		"node_modules/tsx/node_modules/fsevents": {
@@ -14164,9 +14123,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"

--- a/tests/e2e/non-functional/securityHeaders.test.ts
+++ b/tests/e2e/non-functional/securityHeaders.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+
+// Issue #312 HIGH: セキュリティヘッダ未設定の再現テスト。
+// next.config.ts または middleware で主要ヘッダを付与するまで失敗する。
+test.describe("セキュリティヘッダ", () => {
+	const targetPaths = ["/", "/login"];
+
+	for (const path of targetPaths) {
+		test(`${path} のレスポンスに主要セキュリティヘッダが付与されている`, async ({
+			page,
+		}, testInfo) => {
+			test.skip(
+				testInfo.project.name !== "desktop-chromium",
+				"レスポンスヘッダはブラウザに依存しないため desktop-chromium のみ対象",
+			);
+
+			const response = await page.goto(path);
+			expect(response, "ナビゲーションのレスポンスが取得できること").not.toBeNull();
+
+			const headers = response?.headers() ?? {};
+
+			// クリックジャッキング対策
+			expect(
+				headers["x-frame-options"]?.toUpperCase(),
+				"X-Frame-Options が DENY または SAMEORIGIN であること",
+			).toMatch(/^(DENY|SAMEORIGIN)$/);
+
+			// MIME スニッフィング対策
+			expect(
+				headers["x-content-type-options"],
+				"X-Content-Type-Options: nosniff であること",
+			).toBe("nosniff");
+
+			// HSTS（HTTPS強制）
+			expect(
+				headers["strict-transport-security"],
+				"Strict-Transport-Security が設定されていること",
+			).toMatch(/max-age=\d+/);
+
+			// Referrer 漏洩対策
+			expect(
+				headers["referrer-policy"],
+				"Referrer-Policy が設定されていること",
+			).toBeTruthy();
+
+			// XSS 多層防御（CSP）
+			expect(
+				headers["content-security-policy"] ??
+					headers["content-security-policy-report-only"],
+				"Content-Security-Policy が設定されていること",
+			).toBeTruthy();
+		});
+	}
+});


### PR DESCRIPTION
Closes #312

## Summary

アーキテクチャレビュー (`docs/reviews/architecture-review-2026-06-11.html`) のセキュリティ章の指摘を網羅的に対応。

- **CRITICAL: IDOR** — 更新系 5 Action (`removeListItem` / `toggleWatchStatus` / `storeListItem` / `addSubListItem` / `removeSubListItem`) に所有権チェックを追加。参照系と同じ作法に揃え、Action 層で `currentUserId()` を取得し Service 層で照合
- **HIGH: セキュリティヘッダ** — CSP / X-Frame-Options / X-Content-Type-Options / Referrer-Policy / Strict-Transport-Security を `next.config.ts` で全レスポンスに付与
- **HIGH: テストシークレット** — README で対応済みのため本 PR スコープ外
- **MEDIUM: 入力バリデーション** — `renameSubList` の `name` に `.max(50)` 追加、`listItemSchema` の URL に http/https スキーム制限を追加して watchUrl 経由の XSS を防止
- **MEDIUM: レート制限の IP 判定** — `x-forwarded-for` 直読みを撤去し Vercel 信頼ヘッダ (`x-vercel-forwarded-for` / `x-real-ip`) に統一。さらに集計キーを「IP 軸 + target (メール / userId) 軸」の複合に拡張し、IP 偽装と IP 回転の双方を防御。`loginAttemptsTable` に `target_hmac` カラムを追加 (migration 0039)
- **MEDIUM: 依存パッケージ脆弱性** — `npm audit fix` で本番依存の HIGH 以上を全解消。production の `next@16.2.9` は CVE 範囲外で安全と確認。CI に `audit.yml` を追加し PR ごとに `npm audit --audit-level=high --omit=dev` を並列ゲート

## ドキュメント / 運用整備

- `docs/architecture.md` に認可規約 (Service 層責任) を明文化
- `docs/ci.md` 新規: ローカル / CI の検査責任分界、各ワークフローの目的、脆弱性監査の並列方針、ゼロダウンタイム前提のマイグレーション運用方針 (後方互換 / expand-and-contract) を集約
- `wf-migration.yaml` の `node-version: latest` → `24` に固定 (考慮漏れの修正)

## 既知の例外

migration 0039 は後方非互換 (旧コードの INSERT が落ちる) だが、現時点で listpot は未リリースのため実害なしとして許容。リリース後は `docs/ci.md` のマイグレーション運用方針が適用される。

## Test plan

- [x] `npm run test` (209 / 209 passed)
- [x] `npm audit --audit-level=high --omit=dev` が exit 0
- [x] migration が local DB で適用成功
- [x] PR テスト CI (test ジョブ) が green
- [x] PR audit CI (audit ジョブ) が green
- [x] preview deploy で auth フロー (sendLoginCode / login) が機能することを確認
- [x] preview deploy のレスポンスヘッダに CSP / X-Frame-Options 等が乗っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)